### PR TITLE
Expanded coverage for all SpecParam subclasses (REVIEW ONLY)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
@@ -104,7 +104,7 @@ class ZenPack(ZenPackBase):
                     if diff:
                         backup_name = "{}-preupgrade-{}".format(mtname, int(time.time()))
                         deviceclass.rrdTemplates.manage_renameObject(template.id, backup_name)
-                        LOG.info(
+                        self.LOG.info(
                             "Existing monitoring template {}/{} differs from "
                             "the newer version included with the {} ZenPack.  "
                             "The existing template will be "
@@ -128,6 +128,12 @@ class ZenPack(ZenPackBase):
     def remove(self, app, leaveObjects=False):
         if self._v_specparams is None:
             return
+
+        if self.zenpack_spec:
+            archive_path = '/tmp/{}-archive-{}.yaml'.format(self.zenpack_spec.name.lower(), int(time.time()))
+            self.LOG.info("Backing up existing Zenpack YAML to {}".format(archive_path))
+            with open(archive_path, 'w') as archive_path_f:
+                archive_path_f.write(yaml.dump(self.zenpack_spec.specparams, Dumper=Dumper))
 
         from Products.Zuul.interfaces import ICatalogTool
         if leaveObjects:
@@ -269,7 +275,8 @@ class ZenPack(ZenPackBase):
         proto_yaml = yaml.dump(specparam, Dumper=Dumper)
         return self.get_yaml_diff(object_yaml, proto_yaml)
 
-    def get_yaml_diff(self, yaml_existing, yaml_new):
+    @classmethod
+    def get_yaml_diff(cls, yaml_existing, yaml_new):
         """Return diff between YAML files"""
         if yaml_existing != yaml_new:
             lines_existing = [x + '\n' for x in yaml_existing.split('\n')]

--- a/ZenPacks/zenoss/ZenPackLib/lib/base/types.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/base/types.py
@@ -3,6 +3,39 @@ import string
 from Products.ZenRelations.RelSchema import ToMany, ToManyCont, ToOne
 
 
+class Property(object):
+    """Represent _properties entry"""
+    _property_map = {'boolean': 'bool',
+                     'int': 'int',
+                     'float': 'float',
+                     'string': 'str',
+                     'password': 'str',
+                     'lines': 'list(str)',
+                     'text': 'list(str)'
+                     }
+
+    def __new__(cls, value, type_='string', default=None):
+        return object.__new__(cls, cls.validate(value, type_, default))
+
+    @classmethod
+    def validate(cls, value, type, default):
+        # self._pytype = self._property_map.get(value, 'str')
+        return value
+
+    def __init__(self, value, type_='string', default=None):
+        self.name = value
+        self.type_ = type_
+        self.py_type = self._property_map.get(self.type_)
+        self.default = default or self.get_default()
+
+    def get_default(self):
+        return {'string': '',
+                'password': '',
+                'lines': [],
+                'boolean': False,
+            }.get(self.type_, None)
+
+
 class Relationship(str):
     cls = None
     name = None

--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/Dumper.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/Dumper.py
@@ -260,6 +260,7 @@ from ..params.ZPropertySpecParams import ZPropertySpecParams
 from ..params.ClassSpecParams import ClassSpecParams
 from ..params.ClassPropertySpecParams import ClassPropertySpecParams
 from ..params.ClassRelationshipSpecParams import ClassRelationshipSpecParams
+from ..params.RelationshipSchemaSpecParams import RelationshipSchemaSpecParams
 from ..params.RRDTemplateSpecParams import RRDTemplateSpecParams
 from ..params.RRDThresholdSpecParams import RRDThresholdSpecParams
 from ..params.RRDDatasourceSpecParams import RRDDatasourceSpecParams
@@ -286,6 +287,7 @@ Dumper.add_representer(ZPropertySpecParams, Dumper.represent_spec)
 Dumper.add_representer(ClassSpecParams, Dumper.represent_spec)
 Dumper.add_representer(ClassPropertySpecParams, Dumper.represent_spec)
 Dumper.add_representer(ClassRelationshipSpecParams, Dumper.represent_spec)
+Dumper.add_representer(RelationshipSchemaSpecParams, Dumper.represent_relschemaspec)
 Dumper.add_representer(RRDTemplateSpecParams, Dumper.represent_spec)
 Dumper.add_representer(RRDThresholdSpecParams, Dumper.represent_spec)
 Dumper.add_representer(RRDDatasourceSpecParams, Dumper.represent_spec)
@@ -299,6 +301,11 @@ Dumper.add_representer(float, SafeRepresenter.represent_float)
 Dumper.add_representer(int, SafeRepresenter.represent_int)
 Dumper.add_representer(str, SafeRepresenter.represent_str)
 Dumper.add_representer(bool, SafeRepresenter.represent_bool)
+
+from datetime import date, datetime
+Dumper.add_representer(date, SafeRepresenter.represent_date)
+Dumper.add_representer(datetime, SafeRepresenter.represent_datetime)
+
 Dumper.add_representer(EventClassSpecParams, Dumper.represent_spec)
 Dumper.add_representer(EventClassMappingSpec, Dumper.represent_spec)
 Dumper.add_representer(ProcessClassOrganizerSpecParams, Dumper.represent_spec)

--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/Dumper.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/Dumper.py
@@ -139,9 +139,14 @@ class Dumper(yaml.Dumper):
             # it has changed the global default for this parameter.
             if hasattr(obj, 'name') and obj.name != 'DEFAULTS' and defaults is not None:
                 default_value = getattr(defaults, p_name, default_value)
+            # if type_ == 'ZPropertyDefaultValue':
+            #    default_value = obj.get_default()
+                # print 'getting default', obj.name, p_name, p_data, value, default_value
 
             # If the value is a default value, we can omit it from the export.
             if value == default_value:
+                # if type_ == 'ZPropertyDefaultValue':
+                #    print 'skipping {}:{} = {} ({})'.format(obj.name, p_name, value, default_value)
                 continue
 
             # If the value is null and the type is a list or dictionary, we can

--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/utils.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/utils.py
@@ -92,7 +92,7 @@ def load_yaml(yaml_doc=None, verbose=False, level=0):
     if CFG:
         CFG.create()
         end = time.time() - start
-        DEFAULTLOG.debug("Loaded {} in {:0.2f}s".format(CFG.name, end))
+        DEFAULTLOG.info("Loaded {} in {:0.2f}s".format(CFG.name, end))
     else:
         DEFAULTLOG.error("Unable to load {}".format(yaml_doc))
     return CFG

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/ClassPropertySpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/ClassPropertySpecParams.py
@@ -6,6 +6,7 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
+from Acquisition import aq_base
 from .SpecParams import SpecParams
 from ..spec.ClassPropertySpec import ClassPropertySpec
 
@@ -16,3 +17,25 @@ class ClassPropertySpecParams(SpecParams, ClassPropertySpec):
     def __init__(self, class_spec, name, **kwargs):
         SpecParams.__init__(self, **kwargs)
         self.name = name
+
+    @classmethod
+    def fromObject(cls, id, ob):
+        """Generate SpecParams from example object and list of properties"""
+        self = object.__new__(cls)
+        SpecParams.__init__(self)
+
+        ob = aq_base(ob)
+
+        self.name = id
+
+        proto = ob.__class__(ob.id)
+
+        self.default = getattr(proto, id, None)
+
+        entry = next((p for p in proto._properties if p['id'] == id), None)
+
+        if entry:
+            self.type_ = entry.get('type', 'string')
+            self.label = entry.get('label')
+
+        return self

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/ClassPropertySpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/ClassPropertySpecParams.py
@@ -21,8 +21,9 @@ class ClassPropertySpecParams(SpecParams, ClassPropertySpec):
     @classmethod
     def fromObject(cls, id, ob):
         """Generate SpecParams from example object and list of properties"""
-        self = object.__new__(cls)
-        SpecParams.__init__(self)
+        self = super(ClassPropertySpecParams, cls).fromObject(ob)
+        # self = object.__new__(cls)
+        # SpecParams.__init__(self)
 
         ob = aq_base(ob)
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/ClassPropertySpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/ClassPropertySpecParams.py
@@ -32,10 +32,12 @@ class ClassPropertySpecParams(SpecParams, ClassPropertySpec):
 
         self.default = getattr(proto, id, None)
 
-        entry = next((p for p in proto._properties if p['id'] == id), None)
+        entry = next((p for p in proto._properties if p['id'] == id), {})
 
         if entry:
             self.type_ = entry.get('type', 'string')
             self.label = entry.get('label')
+            if entry.get('mode', '') == 'w':
+                self.editable = True
 
         return self

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/ClassPropertySpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/ClassPropertySpecParams.py
@@ -21,9 +21,9 @@ class ClassPropertySpecParams(SpecParams, ClassPropertySpec):
     @classmethod
     def fromObject(cls, id, ob):
         """Generate SpecParams from example object and list of properties"""
-        self = super(ClassPropertySpecParams, cls).fromObject(ob)
-        # self = object.__new__(cls)
-        # SpecParams.__init__(self)
+        # self = super(ClassPropertySpecParams, cls).fromObject(ob)
+        self = object.__new__(cls)
+        SpecParams.__init__(self)
 
         ob = aq_base(ob)
 
@@ -38,6 +38,8 @@ class ClassPropertySpecParams(SpecParams, ClassPropertySpec):
         if entry:
             self.type_ = entry.get('type', 'string')
             self.label = entry.get('label')
+            if self.label == self.name:
+                self.label = None
             if entry.get('mode', '') == 'w':
                 self.editable = True
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/ClassRelationshipSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/ClassRelationshipSpecParams.py
@@ -14,7 +14,16 @@ from ..spec.ClassRelationshipSpec import ClassRelationshipSpec
 class ClassRelationshipSpecParams(SpecParams, ClassRelationshipSpec):
     def __init__(self, class_spec, name, **kwargs):
         SpecParams.__init__(self, **kwargs)
+        self.class_spec = class_spec
         self.name = name
+
+        renderer = 'Zenoss.render.zenpacklib_{zenpack_id_prefix}_entityTypeLinkFromGrid' \
+                if self.render_with_type else 'Zenoss.render.zenpacklib_{zenpack_id_prefix}_entityLinkFromGrid'
+
+        renderer = renderer.format(zenpack_id_prefix=self.class_spec.zenpack_spec.id_prefix)
+        if self.renderer == renderer.format(zenpack_id_prefix=self.class_spec.zenpack_spec.id_prefix):
+            self.renderer = None
+
 
     @classmethod
     def fromObject(cls, rel, ob):
@@ -25,4 +34,5 @@ class ClassRelationshipSpecParams(SpecParams, ClassRelationshipSpec):
         ob = aq_base(ob)
 
         self.name = rel[0]
+
         return self

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/ClassRelationshipSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/ClassRelationshipSpecParams.py
@@ -6,6 +6,7 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
+from Acquisition import aq_base
 from .SpecParams import SpecParams
 from ..spec.ClassRelationshipSpec import ClassRelationshipSpec
 
@@ -14,3 +15,14 @@ class ClassRelationshipSpecParams(SpecParams, ClassRelationshipSpec):
     def __init__(self, class_spec, name, **kwargs):
         SpecParams.__init__(self, **kwargs)
         self.name = name
+
+    @classmethod
+    def fromObject(cls, rel, ob):
+        """Generate SpecParams from example object and list of properties"""
+        self = object.__new__(cls)
+        SpecParams.__init__(self)
+
+        ob = aq_base(ob)
+
+        self.name = rel[0]
+        return self

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/ClassSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/ClassSpecParams.py
@@ -116,7 +116,7 @@ class ClassSpecParams(SpecParams, ClassSpec):
         remote_class = rel_sparm.get_module_class(rel_sparm.right_class)
         remote_classname = remote_class.__name__
 
-        # need to check that reliation is bi-directional between classes and/or their bases
+        # need to check that relation is bi-directional between classes and/or their bases
         if remote_classname not in cls.get_base_names(remote_class) and local_classname not in cls.get_base_names(local_class):
             return False
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/ClassSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/ClassSpecParams.py
@@ -6,10 +6,15 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
+from Acquisition import aq_base
+from Products.ZenModel.ManagedEntity import ManagedEntity
+from Products.ZenModel.Device import Device
 from .SpecParams import SpecParams
 from .ClassPropertySpecParams import ClassPropertySpecParams
 from .ClassRelationshipSpecParams import ClassRelationshipSpecParams
+from .RelationshipSchemaSpecParams import RelationshipSchemaSpecParams
 from .ImpactTriggerSpecParams import ImpactTriggerSpecParams
+from ..spec.RelationshipSchemaSpec import RelationshipSchemaSpec
 from ..spec.ClassSpec import ClassSpec
 
 
@@ -36,3 +41,83 @@ class ClassSpecParams(SpecParams, ClassSpec):
 
         self.impact_triggers = self.specs_from_param(
             ImpactTriggerSpecParams, 'impact_triggers', impact_triggers, leave_defaults=True, zplog=self.LOG)
+
+    @classmethod
+    def fromObject(cls, ob):
+        self = super(ClassSpecParams, cls).fromObject(ob)
+
+        ob = aq_base(ob)
+
+        self.name = ob.__class__.__name__
+
+        bases = cls.get_my_bases(ob.__class__)
+        self.base = tuple([x.__name__ if 'ModelTypeFactory' not in x.__module__ else 'zenpacklib.{}'.format(x.__name__) for x in bases])
+
+        ignore = [x['id'] for x in ManagedEntity._properties]
+        props = [x for x in ob._properties if x['id']  not in ignore]
+        self.properties = {x['id']: ClassPropertySpecParams.fromObject(x['id'], ob) for x in props}
+
+        ignore = [x[0] for x in Device._relations]
+        rels = [x for x in ob._relations if x[0] not in ignore]
+        self.relationships = {x[0]: ClassRelationshipSpecParams.fromObject(x, ob) for x in rels}
+
+        self.monitoring_templates = [t for t in list(getattr(ob, '_templates', [])) if t not in self.base]
+
+        return self
+
+    @classmethod
+    def fromClass(cls, klass):
+        """Generate SpecParams from given class"""
+        return cls.fromObject(klass('ob'))
+
+    @classmethod
+    def get_my_bases(cls, klass):
+        """Return base classes of given class minus implicitly inherited"""
+        bases = cls.get_base_classes(klass, skip_self=True)
+        # remove any bases that already implicitly inherited
+        for base in bases:
+            metas = cls.get_base_classes(base, skip_self=True)
+            bases = [x for x in bases if x not in metas]
+        return bases
+
+    @classmethod
+    def get_base_classes(cls, klass, skip_self=False, skip_schema=True, skip_base=True):
+        bases = []
+        for base in getattr(klass, '__mro__', []):
+            if not hasattr(base, '_relations'):
+                continue
+            if len(base._relations) == 0:
+                continue
+            if skip_base and 'ZenModel' in base.__module__:
+                continue
+            if skip_schema and 'schema' in base.__module__:
+                continue
+            if skip_self and base == klass:
+                continue
+            if base not in bases:
+                bases.append(base)
+        return bases
+
+    @classmethod
+    def get_base_names(cls, klass, skip_self=False, skip_schema=True, skip_base=True):
+        return [x.__name__ for x in cls.get_base_classes(klass, skip_self, skip_schema, skip_base)]
+
+    @classmethod
+    def use_rel(cls, klass, relname):
+        """Return True if this class relations should be dumped"""
+        rel_sparm = RelationshipSchemaSpecParams.fromClass(klass, relname)
+
+        if not RelationshipSchemaSpec.valid_orientation(rel_sparm.left_type, rel_sparm.right_type):
+            return False
+
+        local_class = rel_sparm.get_module_class(rel_sparm.left_class)
+        local_classname = klass.__name__
+
+        remote_class = rel_sparm.get_module_class(rel_sparm.right_class)
+        remote_classname = remote_class.__name__
+
+        # need to check that reliation is bi-directional between classes and/or their bases
+        if remote_classname not in cls.get_base_names(remote_class) and local_classname not in cls.get_base_names(local_class):
+            return False
+
+        return True

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/ClassSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/ClassSpecParams.py
@@ -6,9 +6,10 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
+from collections import OrderedDict
 from Acquisition import aq_base
 from Products.ZenModel.ManagedEntity import ManagedEntity
-from Products.ZenModel.Device import Device
+from Products.ZenModel.Device import Device as BaseDevice
 from .SpecParams import SpecParams
 from .ClassPropertySpecParams import ClassPropertySpecParams
 from .ClassRelationshipSpecParams import ClassRelationshipSpecParams
@@ -16,6 +17,30 @@ from .RelationshipSchemaSpecParams import RelationshipSchemaSpecParams
 from .ImpactTriggerSpecParams import ImpactTriggerSpecParams
 from ..spec.RelationshipSchemaSpec import RelationshipSchemaSpec
 from ..spec.ClassSpec import ClassSpec
+from ..spec.ZenPackSpec import ZenPackSpec
+from ..functions import pluralize
+
+from ..base.Device import Device
+from ..base.Component import (
+    Component,
+    HWComponent,
+    HardwareComponent,
+    CPU,
+    ExpansionCard,
+    Fan,
+    HardDisk,
+    PowerSupply,
+    TemperatureSensor,
+    OSComponent,
+    FileSystem,
+    IpInterface,
+    IpRouteEntry,
+    OSProcess,
+    Service,
+    IpService,
+    WinService
+)
+
 
 
 class ClassSpecParams(SpecParams, ClassSpec):
@@ -50,39 +75,118 @@ class ClassSpecParams(SpecParams, ClassSpec):
             ImpactTriggerSpecParams, 'impact_triggers', impact_triggers, leave_defaults=True, zplog=self.LOG)
 
     @classmethod
-    def fromObject(cls, ob):
+    def fromObject(cls, ob, zenpack=None):
         self = super(ClassSpecParams, cls).fromObject(ob)
 
         ob = aq_base(ob)
 
         self.name = ob.__class__.__name__
 
-        bases = cls.get_my_bases(ob.__class__)
+        klass = ob.__class__
+        bases = cls.get_my_bases(klass)
+        # this might be a non-ZPL class
+        # so we substitute a ZPL proxy classes?\
+        if len(bases) == 0:
+            bases = [cls.find_proxy(klass)]
+
         self.base = tuple([x.__name__ if 'zenpacklib' not in x.__module__ else 'zenpacklib.{}'.format(x.__name__) for x in bases])
 
-        ignore = [x['id'] for x in ManagedEntity._properties]
-        props = [x for x in ob._properties if x['id']  not in ignore]
+        # proto for this should be a ClassSpec with same bases
+        if zenpack:
+            zp_spec = ZenPackSpec(zenpack)
+        else:
+            zp_spec = ZenPackSpec('ZenPacks.zenoss.ZenPackLib')
+
+        proto_spec = ClassSpec(zp_spec, self.name, bases)
+        proto = proto_spec.model_class
+
+        # these have to be handled separately
+        ignore = ['extra_params', 'aliases']
+        # Spec fields
+        propnames = [k for k, v in cls.init_params.items() if k not in ignore and 'SpecsParameter' not in v['type']]
+
+        for propname in propnames:
+            self.handle_prop(ob, proto, propname)
+
+        prop_map = {'class_label': 'label',
+                    'class_plural_label': 'plural_label',
+                    'class_short_label':'short_label',
+                    'class_plural_short_label':'plural_short_label',
+                    'zenpack_name': zp_spec.name}
+        # some object properties might be mapped to differently-named spec properties
+        for ob_prop, spec_prop in prop_map.items():
+            self.handle_prop(ob, proto, ob_prop, spec_prop)
+
+        # any custom object properties not defined in the spec will go in extra_params
+        ignore = [x['id'] for x in ManagedEntity._properties] + cls.init_params.keys()
+        props = [x for x in ob._properties if x['id'] not in ignore]
+
         self.properties = {x['id']: ClassPropertySpecParams.fromObject(x['id'], ob) for x in props}
 
-        ignore = [x[0] for x in Device._relations]
+        ignore = [x[0] for x in BaseDevice._relations]
         rels = [x for x in ob._relations if x[0] not in ignore]
         self.relationships = {x[0]: ClassRelationshipSpecParams.fromObject(x, ob) for x in rels}
 
         self.monitoring_templates = [t for t in list(getattr(ob, '_templates', [])) if t not in cls.get_base_names(ob.__class__)]
+
+        # some of these should be removed if they are defaults
+        meta_type = getattr(self, 'meta_type', None) or getattr(self, 'name', None)
+        label = getattr(self, 'label', None) or getattr(self, 'meta_type', None) or getattr(self, 'name', None)
+        plural_label = pluralize(label)
+        short_label = getattr(self, 'short_label', None) or label
+        plural_short_label = getattr(self, 'plural_short_label', None) or pluralize(short_label)
+
+        dv_group = getattr(self, 'dynamicview_group', None) or {}
+
+        if dv_group.get('name') == plural_short_label:
+            setattr(self, 'dynamicview_group', None)
+
+        if getattr(self, 'plural_short_label', None) == plural_label:
+            setattr(self, 'plural_short_label', None)
+
+        if getattr(self, 'plural_label', None) == plural_label:
+            setattr(self, 'plural_label', None)
+
+        if getattr(self, 'short_label', None) == label:
+            setattr(self, 'short_label', None)
+
+        if getattr(self, 'label', None) == meta_type:
+            setattr(self, 'label', None)
+
+        if getattr(self, 'meta_type', None) == getattr(self, 'name', None):
+            setattr(self, 'meta_type', None)
+
         return self
 
     @classmethod
-    def fromClass(cls, klass):
+    def fromClass(cls, klass, zenpack=None):
         """Generate SpecParams from given class"""
-        return cls.fromObject(klass('ob'))
+        return cls.fromObject(klass('ob'), zenpack)
 
     @classmethod
-    def get_my_bases(cls, klass):
+    def find_proxy(cls, klass):
+        bases = cls.get_base_classes(klass, skip_self=False, skip_base=False)
+        for b in bases:
+            if b == ManagedEntity:
+                continue
+            for x in [CPU, ExpansionCard, Fan,
+                      HardDisk, PowerSupply, TemperatureSensor,
+                      OSComponent, FileSystem, IpInterface,
+                      IpRouteEntry, OSProcess, Service, IpService,
+                      WinService, HardwareComponent, HWComponent, Component, Device]:
+                if issubclass(x, b):
+                    x.__module__ = 'zenpacklib'
+                    return x
+        cls.LOG.warning("No base class found for {}".format(klass.__name__))
+        return Component
+
+    @classmethod
+    def get_my_bases(cls, klass, skip_self=True, skip_schema=True, skip_base=True):
         """Return base classes of given class minus implicitly inherited"""
-        bases = cls.get_base_classes(klass, skip_self=True)
+        bases = cls.get_base_classes(klass, skip_self, skip_schema, skip_base)
         # remove any bases that already implicitly inherited
         for base in bases:
-            metas = cls.get_base_classes(base, skip_self=True)
+            metas = cls.get_base_classes(base, skip_self, skip_schema, skip_base)
             bases = [x for x in bases if x not in metas]
         return bases
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/DeviceClassSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/DeviceClassSpecParams.py
@@ -32,7 +32,7 @@ class DeviceClassSpecParams(SpecParams, DeviceClassSpec):
 
         zprops = [x for x in deviceclass.zenPropertyIds(all=False) if deviceclass.isLocal(x)]
 
-        self.zProperties = {x: ZPropertySpecParams.fromObject(x, deviceclass) for x in zprops}
+        self.zProperties = {x: getattr(deviceclass, x) for x in zprops}
 
         templates = deviceclass.rrdTemplates()
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/DeviceClassSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/DeviceClassSpecParams.py
@@ -6,8 +6,11 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
+from Acquisition import aq_base
 from .SpecParams import SpecParams
 from .RRDTemplateSpecParams import RRDTemplateSpecParams
+from .ZPropertySpecParams import ZPropertySpecParams
+
 from ..spec.DeviceClassSpec import DeviceClassSpec
 
 
@@ -18,3 +21,24 @@ class DeviceClassSpecParams(SpecParams, DeviceClassSpec):
         self.zProperties = zProperties
         self.templates = self.specs_from_param(
             RRDTemplateSpecParams, 'templates', templates, zplog=self.LOG)
+
+    @classmethod
+    def fromObject(cls, deviceclass, zenpack=None):
+        self = super(DeviceClassSpecParams, cls).fromObject(deviceclass)
+
+        deviceclass = aq_base(deviceclass)
+
+        self.path = deviceclass.getOrganizerName().lstrip('/')
+
+        zprops = [x for x in deviceclass.zenPropertyIds(all=False) if deviceclass.isLocal(x)]
+
+        self.zProperties = {x: ZPropertySpecParams.fromObject(x, deviceclass) for x in zprops}
+
+        templates = deviceclass.rrdTemplates()
+
+        if zenpack:
+            templates = [x for x in templates if x in zenpack.packables()]
+
+        self.templates = {x.id: RRDTemplateSpecParams.fromObject(x) for x in templates}
+
+        return self

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/EventClassMappingSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/EventClassMappingSpecParams.py
@@ -6,9 +6,6 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
-
-from Acquisition import aq_base
-
 from .SpecParams import SpecParams
 from ..spec.EventClassMappingSpec import EventClassMappingSpec
 
@@ -38,17 +35,3 @@ class EventClassMappingSpecParams(SpecParams, EventClassMappingSpec):
         self.resolution = resolution
         self.transform = transform
         self.remove = remove
-
-    @classmethod
-    def fromObject(cls, mapping, remove=False):
-        self = object.__new__(cls)
-        SpecParams.__init__(self)
-        mapping = aq_base(mapping)
-
-        _properties = ['eventClassKey', 'sequence', 'rule', 'regex',
-                       'example', 'explanation', 'resolution', 'transform']
-        for x in _properties:
-            setattr(self, x, getattr(mapping, x, None))
-
-        self.remove = remove
-        return self

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/EventClassSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/EventClassSpecParams.py
@@ -6,7 +6,7 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
-
+from Acquisition import aq_base
 from .SpecParams import SpecParams
 from .EventClassMappingSpecParams import EventClassMappingSpecParams
 from ..spec.EventClassSpec import EventClassSpec
@@ -32,12 +32,18 @@ class EventClassSpecParams(SpecParams, EventClassSpec):
         return self
 
     @classmethod
-    def fromObject(cls, eventclass, remove=False):
-        self = object.__new__(cls)
-        SpecParams.__init__(self)
-
-        self.description = eventclass.description
-        self.transform = eventclass.transform
+    def fromObject(cls, eventclass, zenpack=None, remove=True):
+        self = super(EventClassSpecParams, cls).fromObject(eventclass)
         self.remove = remove
-        self.mappings = {x.id: EventClassMappingSpecParams.fromObject(x) for x in eventclass.instances()}
+        eventclass = aq_base(eventclass)
+
+        self.path = eventclass.getOrganizerName()
+
+        mappings = eventclass.instances()
+
+        if zenpack:
+            mappings = [x for x in mappings if x in zenpack.packables()]
+
+        self.mappings = {x.id: EventClassMappingSpecParams.fromObject(x) for x in mappings}
+
         return self

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/GraphDefinitionSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/GraphDefinitionSpecParams.py
@@ -23,25 +23,16 @@ class GraphDefinitionSpecParams(SpecParams, GraphDefinitionSpec):
             GraphPointSpecParams, 'graphpoints', graphpoints, zplog=self.LOG)
 
     @classmethod
-    def fromObject(cls, graphdefinition):
-        self = object.__new__(cls)
-        SpecParams.__init__(self)
-        graphdefinition = aq_base(graphdefinition)
-        sample_gd = graphdefinition.__class__(graphdefinition.id)
+    def fromObject(cls, ob):
+        self = super(GraphDefinitionSpecParams, cls).fromObject(ob)
 
-        for propname in ('height', 'width', 'units', 'log', 'base', 'miny',
-                         'maxy', 'custom', 'hasSummary', 'comments'):
-            if hasattr(sample_gd, propname):
-                setattr(self, '_%s_defaultvalue' % propname, getattr(sample_gd, propname))
-            if getattr(graphdefinition, propname, None) != getattr(sample_gd, propname, None):
-                setattr(self, propname, getattr(graphdefinition, propname, None))
+        ob = aq_base(ob)
 
-        datapoint_graphpoints = [x for x in graphdefinition.graphPoints() if isinstance(x, DataPointGraphPoint)]
-        self.graphpoints = {x.id: GraphPointSpecParams.fromObject(x, graphdefinition) for x in datapoint_graphpoints}
+        datapoint_graphpoints = [x for x in ob.graphPoints() if isinstance(x, DataPointGraphPoint)]
+        self.graphpoints = {x.id: GraphPointSpecParams.fromObject(x, ob) for x in datapoint_graphpoints}
 
-        comment_graphpoints = [x for x in graphdefinition.graphPoints() if isinstance(x, CommentGraphPoint)]
+        comment_graphpoints = [x for x in ob.graphPoints() if isinstance(x, CommentGraphPoint)]
         if comment_graphpoints:
             self.comments = [y.text for y in sorted(comment_graphpoints, key=lambda x: x.id)]
 
         return self
-

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/GraphPointSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/GraphPointSpecParams.py
@@ -18,29 +18,20 @@ class GraphPointSpecParams(SpecParams, GraphPointSpec):
         self.name = name
 
     @classmethod
-    def fromObject(cls, graphpoint, graphdefinition):
-        self = object.__new__(cls)
-        SpecParams.__init__(self)
-        graphpoint = aq_base(graphpoint)
-        graphdefinition = aq_base(graphdefinition)
-        sample_gp = graphpoint.__class__(graphpoint.id)
+    def fromObject(cls, ob, graphdefinition):
+        self = super(GraphPointSpecParams, cls).fromObject(ob)
 
-        for propname in ('lineType', 'lineWidth', 'stacked', 'format',
-                         'legend', 'limit', 'rpn', 'cFunc', 'color', 'dpName'):
-            if hasattr(sample_gp, propname):
-                setattr(self, '_%s_defaultvalue' % propname, getattr(sample_gp, propname))
-            if getattr(graphpoint, propname, None) != getattr(sample_gp, propname, None):
-                setattr(self, propname, getattr(graphpoint, propname, None))
+        ob = aq_base(ob)
 
         threshold_graphpoints = [x for x in graphdefinition.graphPoints() if isinstance(x, ThresholdGraphPoint)]
 
         self.includeThresholds = False
         if threshold_graphpoints:
-            thresholds = {x.id: x for x in graphpoint.graphDef().rrdTemplate().thresholds()}
+            thresholds = {x.id: x for x in ob.graphDef().rrdTemplate().thresholds()}
             for tgp in threshold_graphpoints:
                 threshold = thresholds.get(tgp.threshId, None)
                 if threshold:
-                    if graphpoint.dpName in threshold.dsnames:
+                    if ob.dpName in threshold.dsnames:
                         self.includeThresholds = True
 
         return self

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/ProcessClassOrganizerSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/ProcessClassOrganizerSpecParams.py
@@ -6,7 +6,7 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
-
+from Acquisition import aq_base
 from .SpecParams import SpecParams
 from .ProcessClassSpecParams import ProcessClassSpecParams
 from ..spec.ProcessClassOrganizerSpec import ProcessClassOrganizerSpec
@@ -22,13 +22,20 @@ class ProcessClassOrganizerSpecParams(SpecParams, ProcessClassOrganizerSpec):
             ProcessClassSpecParams, 'process_classes', process_classes)
 
     @classmethod
-    def fromObject(cls, processclass, remove=False):
-        self = object.__new__(cls)
-        SpecParams.__init__(self)
+    def fromObject(cls, processclass, zenpack=None):
+        self = super(ProcessClassOrganizerSpecParams, cls).fromObject(processclass)
 
-        self.description = processclass.description
-        self.remove = remove
-        self.process_classes = {x.id: ProcessClassSpecParams.fromObject(x) for x in processclass.osProcessClasses()}
+        processclass = aq_base(processclass)
+
+        self.path = processclass.getOrganizerName()
+
+        organizers = processclass.osProcessClasses()
+
+        if zenpack:
+            organizers = [x for x in organizers if x in zenpack.packables()]
+
+        self.process_classes = {x.id: ProcessClassSpecParams.fromObject(x) for x in organizers}
+
         return self
 
     @classmethod
@@ -39,3 +46,4 @@ class ProcessClassOrganizerSpecParams(SpecParams, ProcessClassOrganizerSpec):
         self.description = description
         self.remove = remove
         return self
+

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/ProcessClassSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/ProcessClassSpecParams.py
@@ -6,9 +6,6 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
-
-from Acquisition import aq_base
-
 from .SpecParams import SpecParams
 from ..spec.ProcessClassSpec import ProcessClassSpec
 
@@ -44,17 +41,11 @@ class ProcessClassSpecParams(SpecParams, ProcessClassSpec):
         self.send_event_when_blocked = send_event_when_blocked
 
     @classmethod
-    def fromObject(cls, processclass, remove=False):
-        self = object.__new__(cls)
-        SpecParams.__init__(self)
-        processclass = aq_base(processclass)
+    def fromObject(cls, ob):
+        prop_map = {'zMonitor': 'monitor',
+                    'zModelerLock': 'modeler_lock',
+                    'zSendEventWhenBlockedFlag': 'send_event_when_blocked',
+                    'zFailSeverity': 'fail_severity',
+                    'zAlertOnRestart': 'alert_on_restart'}
 
-        _properties = ['description', 'includeRegex', 'excludeRegex',
-                       'replacement', 'zMonitor', 'zAlertOnRestart',
-                       'zFailSeverity', 'zModelerLock', 'zSendEventWhenBlockedFlag']
-
-        for x in _properties:
-            setattr(self, x, getattr(processclass, x, None))
-
-        self.remove = remove
-        return self
+        return super(ProcessClassSpecParams, cls).fromObject(ob, prop_map=prop_map)

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/RRDDatapointSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/RRDDatapointSpecParams.py
@@ -8,7 +8,6 @@
 ##############################################################################
 import StringIO
 from Acquisition import aq_base
-from collections import OrderedDict
 from ..spec.RRDDatapointSpec import RRDDatapointSpec
 from .SpecParams import SpecParams
 
@@ -21,30 +20,11 @@ class RRDDatapointSpecParams(SpecParams, RRDDatapointSpec):
 
     @classmethod
     def fromObject(cls, datapoint):
-        self = object.__new__(cls)
-        SpecParams.__init__(self)
+        self = super(RRDDatapointSpecParams, cls).fromObject(datapoint)
+
         datapoint = aq_base(datapoint)
         sample_dp = datapoint.__class__(datapoint.id)
-
-        for propname in ('name', 'rrdtype', 'createCmd', 'isrow', 'rrdmin',
-                         'rrdmax', 'description',):
-            if hasattr(sample_dp, propname):
-                setattr(self, '_%s_defaultvalue' % propname, getattr(sample_dp, propname))
-            if getattr(datapoint, propname, None) != getattr(sample_dp, propname, None):
-                setattr(self, propname, getattr(datapoint, propname, None))
-
-        if self.rrdmin is not None:
-            self.rrdmin = int(self.rrdmin)
-        if self.rrdmax is not None:
-            self.rrdmax = int(self.rrdmax)
-
         self.aliases = {x.id: x.formula for x in datapoint.aliases()}
-
-        self.extra_params = OrderedDict()
-        for propname in [x['id'] for x in datapoint._properties]:
-            if propname not in self.init_params:
-                if getattr(datapoint, propname, None) != getattr(sample_dp, propname, None):
-                    self.extra_params[propname] = getattr(datapoint, propname, None)
 
         # Shorthand support.  The use of the shorthand field takes
         # over all other attributes.  So we can only use it when the rest of
@@ -63,11 +43,11 @@ class RRDDatapointSpecParams(SpecParams, RRDDatapointSpec):
             shorthand.append(datapoint.rrdtype)
             shorthand_props['rrdtype'] = datapoint.rrdtype
 
-            if datapoint.rrdmin:
+            if datapoint.rrdmin is not None:
                 shorthand.append('MIN_%d' % int(datapoint.rrdmin))
                 shorthand_props['rrdmin'] = datapoint.rrdmin
 
-            if datapoint.rrdmax:
+            if datapoint.rrdmax is not None:
                 shorthand.append('MAX_%d' % int(datapoint.rrdmax))
                 shorthand_props['rrdmax'] = datapoint.rrdmax
 
@@ -104,4 +84,3 @@ class RRDDatapointSpecParams(SpecParams, RRDDatapointSpec):
                     self.shorthand = '_'.join(shorthand)
 
         return self
-

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/RRDDatasourceSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/RRDDatasourceSpecParams.py
@@ -7,7 +7,6 @@
 #
 ##############################################################################
 from Acquisition import aq_base
-from collections import OrderedDict
 from .SpecParams import SpecParams
 from ..spec.RRDDatasourceSpec import RRDDatasourceSpec
 from .RRDDatapointSpecParams import RRDDatapointSpecParams
@@ -21,30 +20,11 @@ class RRDDatasourceSpecParams(SpecParams, RRDDatasourceSpec):
             RRDDatapointSpecParams, 'datapoints', datapoints, zplog=self.LOG)
 
     @classmethod
-    def fromObject(cls, datasource):
-        self = object.__new__(cls)
-        SpecParams.__init__(self)
-        datasource = aq_base(datasource)
+    def fromObject(cls, ob):
+        self = super(RRDDatasourceSpecParams, cls).fromObject(ob)
 
-        # Weed out any values that are the same as they would by by default.
-        # We do this by instantiating a "blank" datapoint and comparing
-        # to it.
-        sample_ds = datasource.__class__(datasource.id)
+        ob = aq_base(ob)
 
-        self.sourcetype = datasource.sourcetype
-        for propname in ('enabled', 'component', 'eventClass', 'eventKey',
-                         'severity', 'commandTemplate'):
-            if hasattr(sample_ds, propname):
-                setattr(self, '_%s_defaultvalue' % propname, getattr(sample_ds, propname))
-            if getattr(datasource, propname, None) != getattr(sample_ds, propname, None):
-                setattr(self, propname, getattr(datasource, propname, None))
-
-        self.extra_params = OrderedDict()
-        for propname in [x['id'] for x in datasource._properties]:
-            if propname not in self.init_params:
-                if getattr(datasource, propname, None) != getattr(sample_ds, propname, None):
-                    self.extra_params[propname] = getattr(datasource, propname, None)
-
-        self.datapoints = {x.id: RRDDatapointSpecParams.fromObject(x) for x in datasource.datapoints()}
+        self.datapoints = {x.id: RRDDatapointSpecParams.fromObject(x) for x in ob.datapoints()}
 
         return self

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/RRDTemplateSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/RRDTemplateSpecParams.py
@@ -30,24 +30,12 @@ class RRDTemplateSpecParams(SpecParams, RRDTemplateSpec):
 
     @classmethod
     def fromObject(cls, template):
-        self = object.__new__(cls)
-        SpecParams.__init__(self)
+        self = super(RRDTemplateSpecParams, cls).fromObject(template)
+
         template = aq_base(template)
-
-        # Weed out any values that are the same as they would by by default.
-        # We do this by instantiating a "blank" template and comparing
-        # to it.
-        sample_template = template.__class__(template.id)
-
-        for propname in ('targetPythonClass', 'description',):
-            if hasattr(sample_template, propname):
-                setattr(self, '_%s_defaultvalue' % propname, getattr(sample_template, propname))
-            if getattr(template, propname, None) != getattr(sample_template, propname, None):
-                setattr(self, propname, getattr(template, propname, None))
 
         self.thresholds = {x.id: RRDThresholdSpecParams.fromObject(x) for x in template.thresholds()}
         self.datasources = {x.id: RRDDatasourceSpecParams.fromObject(x) for x in template.datasources()}
         self.graphs = {x.id: GraphDefinitionSpecParams.fromObject(x) for x in template.graphDefs()}
 
         return self
-

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/RRDThresholdSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/RRDThresholdSpecParams.py
@@ -6,8 +6,6 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
-from Acquisition import aq_base
-from collections import OrderedDict
 from .SpecParams import SpecParams
 from ..spec.RRDThresholdSpec import RRDThresholdSpec
 
@@ -16,25 +14,3 @@ class RRDThresholdSpecParams(SpecParams, RRDThresholdSpec):
     def __init__(self, template_spec, name, foo=None, **kwargs):
         SpecParams.__init__(self, **kwargs)
         self.name = name
-
-    @classmethod
-    def fromObject(cls, threshold):
-        self = object.__new__(cls)
-        SpecParams.__init__(self)
-        threshold = aq_base(threshold)
-        sample_th = threshold.__class__(threshold.id)
-
-        for propname in ('dsnames', 'eventClass', 'severity', 'type_'):
-            if hasattr(sample_th, propname):
-                setattr(self, '_%s_defaultvalue' % propname, getattr(sample_th, propname))
-            if getattr(threshold, propname, None) != getattr(sample_th, propname, None):
-                setattr(self, propname, getattr(threshold, propname, None))
-
-        self.extra_params = OrderedDict()
-        for propname in [x['id'] for x in threshold._properties]:
-            if propname not in self.init_params:
-                if getattr(threshold, propname, None) != getattr(sample_th, propname, None):
-                    self.extra_params[propname] = getattr(threshold, propname, None)
-
-        return self
-

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/RelationshipSchemaSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/RelationshipSchemaSpecParams.py
@@ -1,0 +1,85 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+import importlib
+from Acquisition import aq_base
+from .SpecParams import SpecParams
+from ..spec.RelationshipSchemaSpec import RelationshipSchemaSpec
+from ..base.types import Relationship
+
+
+class RelationshipSchemaSpecParams(SpecParams, RelationshipSchemaSpec):
+    def __init__(self, class_spec, name, **kwargs):
+        SpecParams.__init__(self, **kwargs)
+        self.name = name
+
+    @classmethod
+    def find_schema_on_class(cls, klass, relname):
+        for name, schema in getattr(klass, '_relations', []):
+            if name == relname:
+                return schema
+        return None
+
+    @classmethod
+    def get_module_class(cls, modname):
+        try:
+            module = importlib.import_module(modname)
+        except ImportError:
+            # this might be patched to an existing class with full module & classpath
+            modname = '.'.join(modname.split('.')[:-1])
+            return cls.get_module_class(modname)
+        classname = modname.split('.')[-1]
+        return getattr(module, classname, None)
+
+    @classmethod
+    def fromObject(cls, ob, relname, zenpack='Unknown'):
+        """Generate SpecParams from example object and list of properties"""
+        self = object.__new__(cls)
+        SpecParams.__init__(self)
+
+        ob = aq_base(ob)
+
+        local_schema = cls.find_schema_on_class(ob.__class__, relname)
+
+        remote_modname = local_schema.remoteClass
+        remote_class = cls.get_module_class(remote_modname)
+        remote_classname = remote_class.__name__
+        remote_name = local_schema.remoteName
+        remote_schema = cls.find_schema_on_class(remote_class, remote_name)
+
+        local_class = cls.get_module_class(remote_schema.remoteClass)
+        local_classname = local_class.__name__
+        local_modname = local_class.__module__
+        local_name = relname
+
+        remote_type = Relationship(local_schema.remoteType.__name__)
+        local_type = Relationship(remote_schema.remoteType.__name__)
+
+        self.left_rel = remote_type
+        self.left_class = remote_modname
+
+        if zenpack in remote_modname:
+            self.left_class = remote_classname
+
+        self.left_relname = remote_name
+        self.left_type = local_type.name
+
+        self.right_rel = local_type
+
+        self.right_class = local_modname
+        if zenpack in local_modname:
+            self.right_class = local_classname
+
+        self.right_relname = local_name
+        self.right_type = remote_type.name
+        return self
+
+    @classmethod
+    def fromClass(cls, klass, relname, zenpack='Unknown'):
+        """Generate SpecParams from given class"""
+        return cls.fromObject(klass('ob'), relname, zenpack)

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/SpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/SpecParams.py
@@ -6,6 +6,8 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
+from Acquisition import aq_base
+from collections import OrderedDict
 from ..spec.Spec import Spec
 from ..helpers.ZenPackLibLog import DEFAULTLOG
 from ..base.ClassProperty import ClassProperty
@@ -51,3 +53,51 @@ class SpecParams(object):
 
         return params
 
+    @classmethod
+    def fromObject(cls, ob, prop_map={}):
+        """Generate SpecParams from example object and list of properties"""
+        self = object.__new__(cls)
+        SpecParams.__init__(self)
+
+        ob = aq_base(ob)
+        # Weed out any values that are the same as they would by by default.
+        # We do this by instantiating a "blank" object and comparing
+        # to it.
+        proto = ob.__class__(ob.id)
+
+        def handle_prop(ob, proto, ob_prop, spec_prop=None):
+            """Set default value and possible instance value"""
+            if not spec_prop:
+                spec_prop = ob_prop
+            # find the default for the class
+            if hasattr(proto, ob_prop):
+                setattr(self, '_{}_defaultvalue'.format(spec_prop), getattr(proto, ob_prop))
+            # set it locally if our property differs from the class default
+            if getattr(ob, ob_prop, None) != getattr(proto, ob_prop, None):
+                setattr(self, spec_prop, getattr(ob, ob_prop, None))
+
+        # these have to be handled separately
+        ignore = ['extra_params', 'aliases']
+        # Spec fields
+        propnames = [k for k, v in self.init_params.items() if k not in ignore and 'SpecsParameter' not in v['type']]
+
+        for propname in propnames:
+            handle_prop(ob, proto, propname)
+
+        # some object properties might be mapped to differently-named spec properties
+        for ob_prop, spec_prop in prop_map.items():
+            handle_prop(ob, proto, ob_prop, spec_prop)
+
+        # any custom object properties not defined in the spec will go in extra_params
+        self.extra_params = OrderedDict()
+        ob_propnames = [x['id'] for x in ob._properties if x['id'] not in self.init_params]
+        for propname in ob_propnames:
+            if getattr(ob, propname, None) != getattr(proto, propname, None):
+                self.extra_params[propname] = getattr(ob, propname, None)
+
+        return self
+
+    @classmethod
+    def fromClass(cls, klass, prop_map={}):
+        """Generate SpecParams from given class"""
+        return cls.fromObject(klass('ob'), prop_map)

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/SpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/SpecParams.py
@@ -53,6 +53,22 @@ class SpecParams(object):
 
         return params
 
+    def handle_prop(self, ob, proto, prop_name, spec_prop=None):
+        """Set default value and possible instance value"""
+        if not spec_prop:
+            spec_prop = prop_name
+
+        # find the default for the class
+        default_val = None
+        if hasattr(proto, prop_name):
+            default_val = getattr(proto, prop_name, None)
+            setattr(self, '_{}_defaultvalue'.format(spec_prop), default_val)
+
+        # set it locally if our property differs from the class default
+        local_val = getattr(ob, prop_name, None)
+        if local_val is not None and local_val != default_val:
+            setattr(self, spec_prop, local_val)
+
     @classmethod
     def fromObject(cls, ob, prop_map={}):
         """Generate SpecParams from example object and list of properties"""
@@ -65,34 +81,22 @@ class SpecParams(object):
         # to it.
         proto = ob.__class__(ob.id)
 
-        def handle_prop(ob, proto, ob_prop, spec_prop=None):
-            """Set default value and possible instance value"""
-            if not spec_prop:
-                spec_prop = ob_prop
-            # find the default for the class
-            if hasattr(proto, ob_prop):
-                setattr(self, '_{}_defaultvalue'.format(spec_prop), getattr(proto, ob_prop))
-            # set it locally if our property differs from the class default
-            if getattr(ob, ob_prop, None) != getattr(proto, ob_prop, None):
-                setattr(self, spec_prop, getattr(ob, ob_prop, None))
-            else:
-                print 'skipping {} {} ({})'.format(ob.id, ob_prop, getattr(ob, ob_prop, None))
         # these have to be handled separately
         ignore = ['extra_params', 'aliases']
         # Spec fields
-        propnames = [k for k, v in self.init_params.items() if k not in ignore and 'SpecsParameter' not in v['type']]
+        propnames = [k for k, v in cls.init_params.items() if k not in ignore and 'SpecsParameter' not in v['type']]
 
         for propname in propnames:
-            print 'handling', propname
-            handle_prop(ob, proto, propname)
+            # print 'handling', propname
+            self.handle_prop(ob, proto, propname)
 
         # some object properties might be mapped to differently-named spec properties
         for ob_prop, spec_prop in prop_map.items():
-            handle_prop(ob, proto, ob_prop, spec_prop)
+            self.handle_prop(ob, proto, ob_prop, spec_prop)
 
         # any custom object properties not defined in the spec will go in extra_params
         self.extra_params = OrderedDict()
-        ob_propnames = [x['id'] for x in ob._properties if x['id'] not in self.init_params]
+        ob_propnames = [x['id'] for x in ob._properties if x['id'] not in cls.init_params]
         for propname in ob_propnames:
             if getattr(ob, propname, None) != getattr(proto, propname, None):
                 self.extra_params[propname] = getattr(ob, propname, None)

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/SpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/SpecParams.py
@@ -75,13 +75,15 @@ class SpecParams(object):
             # set it locally if our property differs from the class default
             if getattr(ob, ob_prop, None) != getattr(proto, ob_prop, None):
                 setattr(self, spec_prop, getattr(ob, ob_prop, None))
-
+            else:
+                print 'skipping {} {} ({})'.format(ob.id, ob_prop, getattr(ob, ob_prop, None))
         # these have to be handled separately
         ignore = ['extra_params', 'aliases']
         # Spec fields
         propnames = [k for k, v in self.init_params.items() if k not in ignore and 'SpecsParameter' not in v['type']]
 
         for propname in propnames:
+            print 'handling', propname
             handle_prop(ob, proto, propname)
 
         # some object properties might be mapped to differently-named spec properties

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/ZPropertySpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/ZPropertySpecParams.py
@@ -25,13 +25,13 @@ class ZPropertySpecParams(SpecParams, ZPropertySpec):
         deviceclass = aq_base(deviceclass)
 
         self.name = id
-        entry = next((p.get('type', 'string') for p in deviceclass._properties if p['id'] == id), 'string')
-
-        self.type_ = entry
-
-        self.default = getattr(deviceclass, id)
-
-        self.category = getzPropertyCategory(id)
+#         entry = next((p.get('type', 'string') for p in deviceclass._properties if p['id'] == id), 'string')
+#
+#         self.type_ = entry
+#
+#         self.default = getattr(deviceclass, id)
+#
+#         self.category = getzPropertyCategory(id)
 
         return self
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/ZPropertySpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/ZPropertySpecParams.py
@@ -6,6 +6,8 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
+from Acquisition import aq_base
+from Products.ZenRelations.zPropertyCategory import getzPropertyCategory
 from .SpecParams import SpecParams
 from ..spec.ZPropertySpec import ZPropertySpec
 
@@ -14,3 +16,36 @@ class ZPropertySpecParams(SpecParams, ZPropertySpec):
         SpecParams.__init__(self, **kwargs)
         self.name = name
 
+    @classmethod
+    def fromObject(cls, id, deviceclass):
+        """Generate SpecParams from example object and list of properties"""
+        self = object.__new__(cls)
+        SpecParams.__init__(self)
+
+        deviceclass = aq_base(deviceclass)
+
+        self.name = id
+        entry = next((p.get('type', 'string') for p in deviceclass._properties if p['id'] == id), 'string')
+
+        self.type_ = entry
+
+        self.default = getattr(deviceclass, id)
+
+        self.category = getzPropertyCategory(id)
+
+        return self
+
+    @classmethod
+    def fromTuple(cls, tuple):
+        """Generate SpecParams from tuple entry in ZenPack. packZProperties"""
+        self = object.__new__(cls)
+        SpecParams.__init__(self)
+
+        name, default, type = tuple
+        self.name = name
+        self.type_ = type
+        self.default = default
+
+        self.category = getzPropertyCategory(self.name)
+
+        return self

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/ZenPackSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/ZenPackSpecParams.py
@@ -32,6 +32,7 @@ class ZenPackSpecParams(SpecParams, ZenPackSpec):
                  **kwargs):
         SpecParams.__init__(self, **kwargs)
         self.name = name
+        self.id_prefix = name.replace(".", "_")
 
         self.zProperties = self.specs_from_param(
             ZPropertySpecParams, 'zProperties', zProperties, leave_defaults=True, zplog=self.LOG)

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/ZenPackSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/ZenPackSpecParams.py
@@ -99,6 +99,17 @@ class ZenPackSpecParams(SpecParams, ZenPackSpec):
                                 if relspecparam not in self.class_relationships:
                                     self.class_relationships.append(relspecparam)
 
+        # if relation is M:M, then we want to avoid duplicates
+        for i, rel_i in enumerate(self.class_relationships):
+            if not ('ToMany' == rel_i.left_type == rel_i.right_type):
+                continue
+            for j in range(i):
+                rel_j = self.class_relationships[j]
+                if not ('ToMany' == rel_j.left_type == rel_j.right_type):
+                    continue
+                if rel_i.left_class == rel_j.right_class and rel_i.right_class == rel_j.left_class:
+                    self.class_relationships.remove(rel_j)
+
         if all or class_relationships:
             self.class_relationships.sort(key=lambda x: x.left_class)
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/ZenPackSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/ZenPackSpecParams.py
@@ -6,9 +6,14 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
+import inspect
+import importlib
+from Acquisition import aq_base
+from Products.ZenModel.ManagedEntity import ManagedEntity
 from .SpecParams import SpecParams
 from .ZPropertySpecParams import ZPropertySpecParams
 from .ClassSpecParams import ClassSpecParams
+from .RelationshipSchemaSpecParams import RelationshipSchemaSpecParams
 from .DeviceClassSpecParams import DeviceClassSpecParams
 from .EventClassSpecParams import EventClassSpecParams
 from .ProcessClassOrganizerSpecParams import ProcessClassOrganizerSpecParams
@@ -44,3 +49,78 @@ class ZenPackSpecParams(SpecParams, ZenPackSpec):
 
         self.process_class_organizers = self.specs_from_param(
             ProcessClassOrganizerSpecParams, 'process_class_organizers', process_class_organizers, leave_defaults=True, zplog=self.LOG)
+
+    @classmethod
+    def fromObject(cls, ob,
+                   all=True,
+                   zproperties=False,
+                   classes=False,
+                   class_relationships=False,
+                   device_classes=False,
+                   event_classes=False,
+                   process_classes=False):
+        self = super(ZenPackSpecParams, cls).fromObject(ob)
+
+        ob = aq_base(ob)
+        self.name = ob.id
+
+        # import the ZenPack module
+        zp = importlib.import_module(self.name)
+
+        zp_cls = zp.ZenPack
+
+        # zproperties
+        if all or zproperties:
+            self.zProperties = {x[0]: ZPropertySpecParams.fromTuple(x) for x in zp_cls.packZProperties}
+
+        # classes and class relationships
+        self.classes = {}
+        self.class_relationships = []
+
+        # do not process Device / ManagedEntity Relations
+        ignore_rels = [x[0] for x in ManagedEntity._relations]
+        # iterate through modules of ZP
+        for k, v in zp.__dict__.items():
+            if k in ['schema', 'zenpacklib']:
+                continue
+            if inspect.ismodule(v):
+                for i, j in v.__dict__.items():
+                    if not inspect.isclass(j):
+                        continue
+                    if not issubclass(j, ManagedEntity):
+                        continue
+                    if all or classes:
+                        self.classes[j.__name__] = ClassSpecParams.fromClass(j)
+                    if all or class_relationships:
+                        relnames = [x[0] for x in j._relations if x[0] not in ignore_rels]
+                        for relname in relnames:
+                            if ClassSpecParams.use_rel(j, relname):
+                                relspecparam = RelationshipSchemaSpecParams.fromClass(j, relname, self.name)
+                                if relspecparam not in self.class_relationships:
+                                    self.class_relationships.append(relspecparam)
+
+        if all or class_relationships:
+            self.class_relationships.sort(key=lambda x: x.left_class)
+
+        # device classes/templates
+        if all or device_classes:
+            d_classes = {x.deviceClass() for x in ob.packables() if x.meta_type == 'RRDTemplate'}
+            self.device_classes = {x.getOrganizerName(): DeviceClassSpecParams.fromObject(x, ob) for x in d_classes}
+
+        # event classes
+        if all or event_classes:
+            e_classes = {x for x in ob.packables() if x.meta_type == 'EventClass'}
+            self.event_classes = {x.getOrganizerName(): EventClassSpecParams.fromObject(x, ob, zp) for x in e_classes}
+#             for e in e_classes:
+#                 for sub_e in e.getSubOrganizers():
+#                     self.event_classes[sub_e.getOrganizerName()] = EventClassSpecParams.fromObject(sub_e, ob, zp, remove=False)
+
+        # process class organizers
+        if all or process_classes:
+            p_classes = {x for x in ob.packables() if x.meta_type == 'OSProcessOrganizer'}
+            self.process_classes = {x.getOrganizerName(): ProcessClassOrganizerSpecParams.fromObject(x, ob, zp) for x in p_classes}
+#             for p in p_classes:
+#                 for sub_p in p.getSubOrganizers():
+#                     self.process_classes[sub_p.getOrganizerName()] = ProcessClassOrganizerSpecParams.fromObject(sub_p, ob, zp, remove=False)
+
+        return self

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassPropertySpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassPropertySpec.py
@@ -104,7 +104,7 @@ class ClassPropertySpec(Spec):
             self.LOG = zplog
         self.class_spec = class_spec
         self.name = name
-        self.default = default
+        # self.default = default
         self.type_ = type_
         self.label = label or self.name
         self.short_label = short_label or self.label
@@ -151,6 +151,19 @@ class ClassPropertySpec(Spec):
                 % (name, self.index_scope))
 
         self.order = order
+
+        if default is None:
+            self.default = self.get_default()
+        else:
+            self.default = default
+        # print 'HA', self.name, self.type_, self.category, self.default
+
+    def get_default(self):
+        return {'string': '',
+                'password': '',
+                'lines': [],
+                'boolean': False,
+            }.get(self.type_, None)
 
     @property
     def scaled_order(self):

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassSpec.py
@@ -654,6 +654,7 @@ class ClassSpec(Spec):
             'class_plural_label': self.plural_label,
             'class_short_label': self.short_label,
             'class_plural_short_label': self.plural_short_label,
+            'order': self.order,
             'dynamicview_views': self.dynamicview_views,
             'dynamicview_group': {
                 'name': self.dynamicview_group,

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/EventClassSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/EventClassSpec.py
@@ -44,7 +44,7 @@ class EventClassSpec(Spec):
         self.mappings = self.specs_from_param(
             EventClassMappingSpec, 'mappings', mappings, zplog=self.LOG)
 
-    def instantiate(self, dmd):
+    def instantiate(self, dmd, addToZenPack=True):
         bCreated = False
         try:
             ecObject = dmd.Events.getOrganizer(self.path)
@@ -72,3 +72,11 @@ class EventClassSpec(Spec):
         ecObject.zpl_managed = bCreated
         for mapping_id, mapping_spec in self.mappings.items():
             mapping_spec.create(ecObject)
+
+        # set to false to facilitate testing without ZP installation
+        if addToZenPack:
+            zenpack_name = self.zenpack_spec.name
+            ecObject.addToZenPack(pack=zenpack_name)
+
+        if not addToZenPack:
+            return ecObject

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ProcessClassOrganizerSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ProcessClassOrganizerSpec.py
@@ -37,7 +37,7 @@ class ProcessClassOrganizerSpec(Spec):
         self.process_classes = self.specs_from_param(
             ProcessClassSpec, 'process_classes', process_classes, zplog=self.LOG)
 
-    def create(self, dmd):
+    def create(self, dmd, addToZenPack=True):
         # get/create process class organizer
         bCreated = False
         try:
@@ -55,3 +55,11 @@ class ProcessClassOrganizerSpec(Spec):
         porg.zpl_managed = bCreated
         for process_class_id, process_class_spec in self.process_classes.items():
             process_class_spec.create(dmd, porg)
+
+        # set to false to facilitate testing without ZP installation
+        if addToZenPack:
+            zenpack_name = self.zenpack_spec.name
+            porg.addToZenPack(pack=zenpack_name)
+
+        if not addToZenPack:
+            return porg

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDDatapointSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDDatapointSpec.py
@@ -94,11 +94,7 @@ class RRDDatapointSpec(Spec):
         # otherwise build the shorthand if no other properties are found
         else:
             if self.use_shorthand():
-                self.shorthand = self.rrdtype
-                if self.rrdmin is not None:
-                    self.shorthand += '_MIN_{}'.format(str(self.rrdmin))
-                if self.rrdmax is not None:
-                    self.shorthand += '_MAX_{}'.format(self.rrdmax)
+                self.shorthand = self.get_shorthand()
 
     def __eq__(self, other):
         if self.shorthand:
@@ -176,6 +172,14 @@ class RRDDatapointSpec(Spec):
             if getattr(self, x):
                 return False
         return True
+
+    def get_shorthand(self):
+        shorthand = self.rrdtype
+        if self.rrdmin is not None:
+            shorthand += '_MIN_{}'.format(str(self.rrdmin))
+        if self.rrdmax is not None:
+            shorthand += '_MAX_{}'.format(self.rrdmax)
+        return shorthand
 
     def create(self, datasource_spec, datasource):
         datapoint = datasource.manage_addRRDDataPoint(self.name)

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ZPropertySpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ZPropertySpec.py
@@ -12,6 +12,7 @@ from .Spec import Spec
 
 class ZPropertySpec(Spec):
     """ZPropertySpec"""
+    _default = None
 
     def __init__(
             self,
@@ -44,14 +45,16 @@ class ZPropertySpec(Spec):
         self.category = category
 
         if default is None:
-            self.default = {
-                'string': '',
+            self.default = self.get_default()
+        else:
+            self.default = default
+
+    def get_default(self):
+        return {'string': '',
                 'password': '',
                 'lines': [],
                 'boolean': False,
             }.get(self.type_, None)
-        else:
-            self.default = default
 
     def create(self):
         """Implement specification."""

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ZPropertySpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ZPropertySpec.py
@@ -7,7 +7,11 @@
 #
 ##############################################################################
 from Products.ZenRelations.zPropertyCategory import setzPropertyCategory
+from ..base.ClassProperty import ClassProperty
 from .Spec import Spec
+import inspect
+from collections import OrderedDict
+import re
 
 
 class ZPropertySpec(Spec):
@@ -43,11 +47,11 @@ class ZPropertySpec(Spec):
         self.name = name
         self.type_ = type_
         self.category = category
-
         if default is None:
             self.default = self.get_default()
         else:
             self.default = default
+        # print 'HA', self.name, self.type_, self.category, self.default
 
     def get_default(self):
         return {'string': '',
@@ -65,3 +69,66 @@ class ZPropertySpec(Spec):
     def packZProperties(self):
         """Return packZProperties tuple for this zProperty."""
         return (self.name, self.default, self.type_)
+#
+#     @ClassProperty
+#     @classmethod
+#     def init_params(cls):
+#         # if not cls._init_params:
+#             return cls.get_init_params()
+#         # return cls._init_params
+#
+#     # @classmethod
+#     # def get_init_params(cls):
+#         # params = super(ZPropertySpec, cls).get_init_params()
+#
+#         # params['type_']['type'] = cls.type_
+#         # params['default']['default'] = self.get_default()
+#
+#         # return params
+#
+#     @classmethod
+#     def get_init_params(cls):
+#         """Return a dictionary describing the parameters accepted by __init__"""
+#         # import pdb ; pdb.set_trace()
+#         argspec = inspect.getargspec(cls.__init__)
+#         if argspec.defaults:
+#             defaults = dict(zip(argspec.args[-len(argspec.defaults):], argspec.defaults))
+#         else:
+#             defaults = {}
+#
+#         params = OrderedDict()
+#         for op, param, value in re.findall(
+#             "^\s*:(type|param|yaml_param|yaml_block_style)\s+(\S+):\s*(.*)$",
+#             cls.__init__.__doc__,
+#             flags=re.MULTILINE
+#         ):
+#             print op, param
+#             if param not in params:
+#                 params[param] = {'description': None,
+#                                  'type': None,
+#                                  'yaml_param': param,
+#                                  'yaml_block_style': False}
+#                 if param in defaults:
+#                     params[param]['default'] = defaults[param]
+#
+#             if op == 'type':
+#                 params[param]['type'] = value
+#
+#                 if 'default' not in params[param] or \
+#                    params[param]['default'] is None:
+#                     # For certain types, we know that None doesn't really mean
+#                     # None.
+#                     if params[param]['type'].startswith("dict"):
+#                         params[param]['default'] = {}
+#                     elif params[param]['type'].startswith("list"):
+#                         params[param]['default'] = []
+#                     elif params[param]['type'].startswith("SpecsParameter("):
+#                         params[param]['default'] = {}
+#             elif op == 'yaml_param':
+#                 params[param]['yaml_param'] = value
+#             elif op == 'yaml_block_style':
+#                 params[param]['yaml_block_style'] = bool(value)
+#             else:
+#                 params[param]['description'] = value
+#
+#         return params

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ZenPackSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ZenPackSpec.py
@@ -558,7 +558,7 @@ class ZenPackSpec(Spec):
         attributes = {
             'packZProperties': packZProperties
             }
-
+        attributes['zenpack_spec'] = self
         attributes['device_classes'] = self.device_classes
         attributes['event_classes'] = self.event_classes
         attributes['process_class_organizers'] = self.process_class_organizers

--- a/ZenPacks/zenoss/ZenPackLib/tests/ZPLTestHarness.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/ZPLTestHarness.py
@@ -66,7 +66,7 @@ class ZPLTestHarness(ZenScriptBase):
         # create relations between objects
         self.build_relations()
         self.build_cfg_relations()
-        self.exported_yaml = yaml.dump(self.cfg, Dumper=Dumper)
+        self.exported_yaml = yaml.dump(self.cfg.specparams, Dumper=Dumper)
         self.reloaded_yaml = load_yaml_single(self.exported_yaml, useLoader=False)
 
     def build_ob(self, cls_name, inst=0):

--- a/ZenPacks/zenoss/ZenPackLib/zenpacklib.py
+++ b/ZenPacks/zenoss/ZenPackLib/zenpacklib.py
@@ -63,6 +63,17 @@ from lib.base.Component import (
     WinService
 )
 
+def find_proxy(klass):
+    for x in [ Device, CPU, ExpansionCard, Fan,
+              HardDisk, PowerSupply, TemperatureSensor,
+              OSComponent, FileSystem, IpInterface,
+              IpRouteEntry, OSProcess, Service, IpService,
+              WinService, HardwareComponent, HWComponent, Component]:
+        if issubclass(x, klass):
+            return x
+    return None
+
+
 from lib.spec import ZenPackSpec
 from lib.functions import relationships_from_yuml, catalog_search, ucfirst, relname_from_classname
 


### PR DESCRIPTION
- Extended "fromObject" to cover all ZPL objects
- Added "fromClass" method to all SpecParams
- ZP installation now saves old YAML
- zenpacklib supports dumping from both ZenPacks and
Device/Event/Process organizer paths
- added "--dump-all" to export YAML of existing ZenPack