### PR TITLE
Fix inaccurate datapoint YAML dump (ZEN-26593)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -18,6 +18,14 @@ Backwards Incompatible Changes
 
 * zProperties will not be updated automatically on existing device classes.  These should be handled on a case basis by using migrate scripts.
 
+Release 2.0.1
+-------------
+
+Fixes
+
+* Ensure all datapoint attributes export to YAML (ZEN-26593)
+
+
 Release 2.0.0
 -------------
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/Dumper.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/Dumper.py
@@ -107,7 +107,7 @@ class Dumper(yaml.Dumper):
         """
         from ..spec.RRDDatapointSpec import RRDDatapointSpec
         cls = obj.__class__
-        if isinstance(obj, RRDDatapointSpec) and obj.shorthand:
+        if isinstance(obj, RRDDatapointSpec) and obj.shorthand and obj.use_shorthand():
             # Special case- we allow for a shorthand in specifying datapoints
             # as specs as strings rather than explicitly as a map.
             return self.represent_str(str(obj.shorthand))


### PR DESCRIPTION
- Fixes ZEN-26593
- Corrects issue where datapoint aliases inadvertently removed from YAML
output
- Updated Dumper to use "use_shorthand" method in addition to existence
test
of 'shorthand' when outputting to YAML