### PR TITLE
Fix potential traceback during ZP install

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
@@ -64,9 +64,15 @@ class ZenPack(ZenPackBase):
         for dcname, dcspec in self.device_classes.iteritems():
             if dcspec.create:
                 dcObject = self.create_device_class(app, dcspec)
-
+            else:
+                try:
+                    dcObject = self.dmd.Devices.getOrganizer(dcspec.path)
+                except KeyError:
+                    self.LOG.warn('Device Class ({}) not found'.format(dcspec.path))
+                    dcObject = None
             # if device class has description and protocol, register a devtype
-            if dcspec.description and dcspec.protocol:
+
+            if dcObject and dcspec.description and dcspec.protocol:
                 try:
                     if (dcspec.description, dcspec.protocol) not in dcObject.devtypes:
                         self.LOG.info('Registering devtype for {}: {} ({})'.format(dcObject,

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # or saved.  Do not modify them directly here.
 # NB: PACKAGES is deprecated
 NAME = "ZenPacks.zenoss.ZenPackLib"
-VERSION = "2.0.0"
+VERSION = "2.0.1"
 AUTHOR = "Zenoss"
 LICENSE = ""
 NAMESPACE_PACKAGES = ['ZenPacks', 'ZenPacks.zenoss']


### PR DESCRIPTION
- Added device class retrieval and logging if device class not found
- Error could occur if DeviceClassSpec "create" attribute is set to
False, but target device class doesn't exist.