### PR TITLE
Fix ZP installation reattempts (ZPS-627)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -24,6 +24,7 @@ Release 2.0.1
 Fixes
 
 * Ensure all datapoint attributes export to YAML (ZEN-26593)
+* Ensure subsquent installations complete if ZP install fails (ZPS-627)
 
 
 Release 2.0.0

--- a/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
@@ -162,6 +162,15 @@ class ZenPack(ZenPackBase):
 
                     # back up the template
                     backup_name = "{}-backup".format(orig_mtname)
+                    # delete the template if it already exists
+                    # this could occur if zenpack installation fails and is reattempted
+                    try:
+                        backup_template = deviceclass.rrdTemplates._getOb(backup_name)
+                        if backup_template:
+                            backup_template.getPrimaryParent()._delObject(backup_template.id)
+                    except AttributeError:
+                        pass
+
                     deviceclass.rrdTemplates.manage_renameObject(template.id, backup_name)
         else:
             dc = app.Devices


### PR DESCRIPTION
- Fixes ZPS-627
- Corrects issue where if ZenPack installation terminates prematurely,
backup files are left behind