### PR TITLE
Handle Unit Test dependency issues

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/libexec/ZPLCommand.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/libexec/ZPLCommand.py
@@ -122,7 +122,10 @@ class ZPLCommand(ZenScriptBase):
         '''Determine if ZenPack is valid'''
         self.connect()
         self.app = self.dmd
-        zenpack = self.dmd.ZenPackManager.packs._getOb(self.options.zenpack)
+        try:
+            zenpack = self.dmd.ZenPackManager.packs._getOb(self.options.zenpack)
+        except AttributeError:
+            zenpack = None
         if zenpack is None:
             return False
         return True

--- a/ZenPacks/zenoss/ZenPackLib/tests/ZPLTestHarness.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/ZPLTestHarness.py
@@ -54,11 +54,11 @@ class ZPLTestHarness(ZenScriptBase):
     '''Class containing methods to build out dummy objects representing YAML class instances'''
     templates = None
 
-    def __init__(self, filename, connect=False, verbose=False):
+    def __init__(self, filename, connect=False, verbose=False, level=20):
         ''''''
         ZenScriptBase.__init__(self)
         self.filename = filename
-        self.cfg = zenpacklib.load_yaml(filename, verbose=verbose)
+        self.cfg = zenpacklib.load_yaml(filename, verbose=verbose, level=level)
         self.yaml = load_yaml_single(filename, useLoader=False)
         self.zp = self.cfg.zenpack_module
         self.schema = self.zp.schema
@@ -68,6 +68,17 @@ class ZPLTestHarness(ZenScriptBase):
         self.build_cfg_relations()
         self.exported_yaml = yaml.dump(self.cfg, Dumper=Dumper)
         self.reloaded_yaml = load_yaml_single(self.exported_yaml, useLoader=False)
+
+    def zenpack_installed(self):
+        '''Return True if ZenPack is installed'''
+        self.connect()
+        try:
+            zenpack = self.dmd.ZenPackManager.packs._getOb(self.cfg.name)
+        except AttributeError:
+            zenpack = None
+        if zenpack:
+            return True
+        return False
 
     def build_ob(self, cls_name, inst=0):
         '''build an instance object from schema class'''

--- a/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/hp_proliant.yaml
+++ b/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/hp_proliant.yaml
@@ -1,4 +1,4 @@
-name: ZenPacks.zenoss.ZenPackLib
+name: ZenPacks.zenoss.HP.Proliant
 zProperties:
   DEFAULTS:
     category: ILO

--- a/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/ibm_power.yaml
+++ b/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/ibm_power.yaml
@@ -1,4 +1,4 @@
-name: ZenPacks.zenoss.ZenPackLib
+name: ZenPacks.zenoss.IBM.Power
 class_relationships:
 ##################### STANDARD RELATIONS #####################
 

--- a/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/ms_windows.yaml
+++ b/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/ms_windows.yaml
@@ -32,7 +32,7 @@ zProperties:
 
 
 class_relationships:
-  - ZenPacks.zenoss.Microsoft.Windows.OperatingSystem.OperatingSystem(winrmservices) 1:MC (os)WinService
+  - ZenPacks.zenoss.Microsoft.Windows.OperatingSystem.OperatingSystem(winrmservices) 1:MC (os)ZenPacks.zenoss.Microsoft.Windows.WinService.WinService
   - ZenPacks.zenoss.Microsoft.Windows.OperatingSystem.OperatingSystem(winrmiis) 1:MC (os)WinIIS
   - ZenPacks.zenoss.Microsoft.Windows.OperatingSystem.OperatingSystem(winsqlinstances) 1:MC (os)WinSQLInstance
   - ZenPacks.zenoss.Microsoft.Windows.OperatingSystem.OperatingSystem(clusterservices) 1:MC (os)ClusterService

--- a/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/openstack.yaml
+++ b/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/openstack.yaml
@@ -1,4 +1,4 @@
-name: ZenPacks.zenoss.ZenPackLib
+name: ZenPacks.zenoss.OpenStackInfrastructure
 zProperties:
   DEFAULTS:
     category: OpenStack

--- a/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/vsphere.yaml
+++ b/ZenPacks/zenoss/ZenPackLib/tests/data/yaml/vsphere.yaml
@@ -1,4 +1,4 @@
-name: ZenPacks.zenoss.ZenPackLib
+name: ZenPacks.zenoss.vSphere
 
 zProperties:
   DEFAULTS:

--- a/ZenPacks/zenoss/ZenPackLib/tests/data/zenpacks/ZenPacks.zenoss.ZPLTest1/ZenPacks/zenoss/ZPLTest1/zenpack.yaml
+++ b/ZenPacks/zenoss/ZenPackLib/tests/data/zenpacks/ZenPacks.zenoss.ZPLTest1/ZenPacks/zenoss/ZPLTest1/zenpack.yaml
@@ -292,7 +292,7 @@ classes:
         label_width: 85
         content_width: 160
         renderer: Zenoss.render.default_uid_renderer
-        order: 4.1
+        order: 41
         api_only: true
         api_backendtype: method
       vsphere_dvportgroup_ids:
@@ -300,7 +300,7 @@ classes:
         label: VMware vSphere dvPortgroup IDs
         index_type: keyword
         grid_display: false
-        order: 4.2
+        order: 42
     impacts: [fvAp, impacts_fvAEPgs, impacts_vnsGraphInsts]
     impacted_by: [fvBD, impacted_by_fvAEPgs, impacted_by_vnsGraphInsts, vsphere_dvportgroups,
       vsphere_vms, devices]
@@ -332,14 +332,14 @@ classes:
     plural_label: Contracts Consumed
     short_label: Consumes
     plural_short_label: Consumes
-    order: 14.2
+    order: 14
   FvRsProv:
     meta_type: ZPLTest1ContractProvided
     label: Contract Provided
     plural_label: Contracts Provided
     short_label: Provides
     plural_short_label: Provides
-    order: 14.1
+    order: 13
   FvTenant:
     meta_type: ZPLTest1Tenant
     label: Tenant
@@ -354,15 +354,15 @@ classes:
     properties:
       layer:
         label: Layer
-        order: 4.3
+        order: 3
       portT:
         label: Port Type
-        order: 4.2
+        order: 2
       speed:
         type: int
         label: Speed
         renderer: Zenoss.render.ZPLTest1_linkSpeed
-        order: 4.1
+        order: 1
     monitoring_templates: [L1PhysIf, Health]
   ManagedObject:
     base: [zenpacklib.Component]
@@ -370,16 +370,16 @@ classes:
       apic_classname:
         label: ACI Object Class
         grid_display: false
-        order: 4.93
+        order: 93
       apic_dn:
         label: ACI Distinguished Name (DN)
         index_type: field
         grid_display: false
-        order: 4.91
+        order: 91
       apic_health_dn:
         label: ACI Health Distinguished Name (DN)
         grid_display: false
-        order: 4.92
+        order: 92
   VnsCDev:
     meta_type: ZPLTest1VnsCDev
     label: Service Device
@@ -389,20 +389,20 @@ classes:
         label: Management Address
         index_type: field
         grid_display: false
-        order: 4.4
+        order: 4
       cmgmt_port:
         label: Management Port
         grid_display: false
-        order: 4.5
+        order: 5
       devCtxLbl:
         label: Context Label
-        order: 4.1
+        order: 6
       vcenterName:
         label: vCenter Name
-        order: 4.3
+        order: 7
       vmName:
         label: VM Name
-        order: 4.2
+        order: 8
     impacts: [vnsLDevVip]
     impacted_by: [cmgmt_devices]
     monitoring_templates: [Health]
@@ -416,7 +416,7 @@ classes:
         label: Graph DN
         label_width: 55
         content_width: 230
-        order: 4.1
+        order: 4
     impacts: [impacts_fvAEPgs]
     impacted_by: [impacted_by_fvAEPgs, vnsNodeInsts]
   VnsLDevVip:
@@ -428,27 +428,27 @@ classes:
         label: Management Address
         index_type: field
         grid_display: false
-        order: 4.6
+        order: 6
       cmgmt_port:
         label: Management Port
         grid_display: false
-        order: 4.7
+        order: 7
       contextAware:
         label: Context Aware
-        order: 4.3
+        order: 3
       devtype:
         label: Device Type
-        order: 4.1
+        order: 1
       funcType:
         label: Function Type
         grid_display: false
-        order: 4.5
+        order: 5
       mgmtType:
         label: Management Type
-        order: 4.2
+        order: 2
       mode:
         label: Mode
-        order: 4.4
+        order: 4
     impacts: [vnsNodeInsts]
     impacted_by: [vnsCDevs]
   VnsNodeInst:
@@ -459,12 +459,12 @@ classes:
     properties:
       funcType:
         label: Function Type
-        order: 4.1
+        order: 1
       lbvserver_name:
         label: Load Balancer Virtual Server Name
         index_type: field
         grid_display: false
-        order: 4.9
+        order: 9
     impacts: [vnsGraphInst]
     impacted_by: [vnsLDevVip, netscaler_virtual_servers]
   VzBrCP:

--- a/ZenPacks/zenoss/ZenPackLib/tests/data/zenpacks/ZenPacks.zenoss.ZPLTest1/ZenPacks/zenoss/ZPLTest1/zenpack2.yaml
+++ b/ZenPacks/zenoss/ZenPackLib/tests/data/zenpacks/ZenPacks.zenoss.ZPLTest1/ZenPacks/zenoss/ZPLTest1/zenpack2.yaml
@@ -292,7 +292,7 @@ classes:
         label_width: 85
         content_width: 160
         renderer: Zenoss.render.default_uid_renderer
-        order: 4.1
+        order: 1
         api_only: true
         api_backendtype: method
       vsphere_dvportgroup_ids:
@@ -300,7 +300,7 @@ classes:
         label: VMware vSphere dvPortgroup IDs
         index_type: keyword
         grid_display: false
-        order: 4.2
+        order: 2
     impacts: [fvAp, impacts_fvAEPgs, impacts_vnsGraphInsts]
     impacted_by: [fvBD, impacted_by_fvAEPgs, impacted_by_vnsGraphInsts, vsphere_dvportgroups,
       vsphere_vms, devices]
@@ -332,14 +332,14 @@ classes:
     plural_label: Contracts Consumed
     short_label: Consumes
     plural_short_label: Consumes
-    order: 14.2
+    order: 14
   FvRsProv:
     meta_type: ZPLTest1ContractProvided
     label: Contract Provided
     plural_label: Contracts Provided
     short_label: Provides
     plural_short_label: Provides
-    order: 14.1
+    order: 13
   FvTenant:
     meta_type: ZPLTest1Tenant
     label: Tenant
@@ -354,15 +354,15 @@ classes:
     properties:
       layer:
         label: Layer
-        order: 4.3
+        order: 3
       portT:
         label: Port Type
-        order: 4.2
+        order: 2
       speed:
         type: int
         label: Speed
         renderer: Zenoss.render.ZPLTest1_linkSpeed
-        order: 4.1
+        order: 1
     monitoring_templates: [L1PhysIf, Health]
   ManagedObject:
     base: [zenpacklib.Component]
@@ -370,16 +370,16 @@ classes:
       apic_classname:
         label: ACI Object Class
         grid_display: false
-        order: 4.93
+        order: 93
       apic_dn:
         label: ACI Distinguished Name (DN)
         index_type: field
         grid_display: false
-        order: 4.91
+        order: 91
       apic_health_dn:
         label: ACI Health Distinguished Name (DN)
         grid_display: false
-        order: 4.92
+        order: 92
   VnsCDev:
     meta_type: ZPLTest1VnsCDev
     label: Service Device
@@ -389,20 +389,20 @@ classes:
         label: Management Address
         index_type: field
         grid_display: false
-        order: 4.4
+        order: 4
       cmgmt_port:
         label: Management Port
         grid_display: false
-        order: 4.5
+        order: 5
       devCtxLbl:
         label: Context Label
-        order: 4.1
+        order: 1
       vcenterName:
         label: vCenter Name
-        order: 4.3
+        order: 3
       vmName:
         label: VM Name
-        order: 4.2
+        order: 2
     impacts: [vnsLDevVip]
     impacted_by: [cmgmt_devices]
     monitoring_templates: [Health]
@@ -416,7 +416,7 @@ classes:
         label: Graph DN
         label_width: 55
         content_width: 230
-        order: 4.1
+        order: 1
     impacts: [impacts_fvAEPgs]
     impacted_by: [impacted_by_fvAEPgs, vnsNodeInsts]
   VnsLDevVip:
@@ -428,27 +428,27 @@ classes:
         label: Management Address
         index_type: field
         grid_display: false
-        order: 4.6
+        order: 6
       cmgmt_port:
         label: Management Port
         grid_display: false
-        order: 4.7
+        order: 7
       contextAware:
         label: Context Aware
-        order: 4.3
+        order: 3
       devtype:
         label: Device Type
-        order: 4.1
+        order: 1
       funcType:
         label: Function Type
         grid_display: false
-        order: 4.5
+        order: 5
       mgmtType:
         label: Management Type
-        order: 4.2
+        order: 2
       mode:
         label: Mode
-        order: 4.4
+        order: 4
     impacts: [vnsNodeInsts]
     impacted_by: [vnsCDevs]
   VnsNodeInst:
@@ -459,12 +459,12 @@ classes:
     properties:
       funcType:
         label: Function Type
-        order: 4.1
+        order: 1
       lbvserver_name:
         label: Load Balancer Virtual Server Name
         index_type: field
         grid_display: false
-        order: 4.9
+        order: 9
     impacts: [vnsGraphInst]
     impacted_by: [vnsLDevVip, netscaler_virtual_servers]
   VzBrCP:

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_classes.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_classes.py
@@ -43,13 +43,17 @@ class TestClasses(BaseTestCase):
     def test_ZP(self):
         for file in self.files:
             try:
-                zp = ZPLTestHarness(file)
-                self.assertTrue(zp.check_properties(), "Property testing failed for {}".format(zp.filename))
-                self.assertTrue(zp.check_cfg_relations(), "Relation testing failed for {}".format(zp.filename))
-                self.assertTrue(zp.check_templates_vs_yaml(), "Template (YAML) testing failed for {}".format(zp.filename))
-                self.assertTrue(zp.check_templates_vs_specs(), "Template (Spec) testing failed for {}".format(zp.filename))
+                zp = ZPLTestHarness(file, verbose=True, level=40)
+                # only run if target ZP is installed
+                if zp.zenpack_installed():
+                    self.assertTrue(zp.check_properties(), "Property testing failed for {}".format(zp.filename))
+                    self.assertTrue(zp.check_cfg_relations(), "Relation testing failed for {}".format(zp.filename))
+                    self.assertTrue(zp.check_templates_vs_yaml(), "Template (YAML) testing failed for {}".format(zp.filename))
+                    self.assertTrue(zp.check_templates_vs_specs(), "Template (Spec) testing failed for {}".format(zp.filename))
+                else:
+                    print '\nSkipping test_zp since {} not installed'.format(zp.cfg.name)
             except Exception as e:
-                print 'Skipping test {} ({})'.format(file, e)
+                print '\nSkipping test_zp {} ({})'.format(file, e)
 
 
 def test_suite():

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_commands.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_commands.py
@@ -28,9 +28,12 @@ LOG = logging.getLogger('zen.zenpacklib.tests')
 
 
 from ZenPacks.zenoss.ZenPackLib.tests.BaseTestCommand import BaseTestCommand
-
+from ZenPacks.zenoss.ZenPackLib.tests.ZPLTestHarness import ZPLTestHarness
 from ZenPacks.zenoss.ZenPackLib.tests.test_install import TestInstall, get_cmd_output
 
+YAML_DOC = '''
+name: ZenPacks.zenoss.DnsMonitor
+'''
 
 class TestCommands(BaseTestCommand):
 
@@ -52,13 +55,12 @@ class TestCommands(BaseTestCommand):
     def test_smoke_lint(self):
         self._smoke_command("--lint", self.yaml_path)
 
-    # Can't be tested with ZPLTest1, because that is already using YAML.
-    # Need to build another small zenpack if we want to do that.
-    # def test_smoke_py_to_yaml(self):
-    #     self._smoke_command("py_to_yaml", self.zenpack_name)
-
     def test_smoke_dump_templates(self):
-        self._smoke_command("--dump-templates", 'ZenPacks.zenoss.DnsMonitor')
+        z = ZPLTestHarness(YAML_DOC)
+        if z.zenpack_installed():
+            self._smoke_command("--dump-templates", 'ZenPacks.zenoss.DnsMonitor')
+        else:
+            print '\nSkipping test_smoke_dump_templates since ZenPacks.zenoss.DnsMonitor not installed.'
 
     def test_smoke_class_diagram(self):
         self._smoke_command("--diagram", self.yaml_path)

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_subcomponent_nav_js.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_subcomponent_nav_js.py
@@ -25,17 +25,8 @@ from Products.ZenTestCase.BaseTestCase import BaseTestCase
 # zenpacklib Imports
 from ZenPacks.zenoss.ZenPackLib.tests.ZPLTestHarness import ZPLTestHarness
 
-def vsphere_installed():
-    """Return True if vSphere is installed"""
-    try:
-        from ZenPacks.zenoss.vSphere.Datacenter import Datacenter
-    except ImportError:
-        pass
-    else:
-        return True
-    return False
 
-YAML_DOC = """name: ZenPacks.zenoss.ZenPackLib
+YAML_DOC = """name: ZenPacks.zenoss.vSphere
 class_relationships:
   - Endpoint 1:MC Datacenter
   - Endpoint 1:MC Folder
@@ -998,8 +989,8 @@ class TestSubComponentNavJS(BaseTestCase):
 
     def test_nav_js(self):
         ''''''
-        if not vsphere_installed():
-            z = ZPLTestHarness(YAML_DOC)
+        z = ZPLTestHarness(YAML_DOC)
+        if z.zenpack_installed():
             cls = z.cfg.classes.get('ResourcePool')
             self.assertEquals(cls.subcomponent_nav_js_snippet,
                               expected_rp,
@@ -1010,7 +1001,7 @@ class TestSubComponentNavJS(BaseTestCase):
                               expected_va,
                               'Unexpected subcomponent_nav_js_snippet for ResourcePool')
         else:
-            print "TestSubComponentNavJS cannot run if ZenPacks.zenoss.vSphere is installed"
+            print "\nSkipping TestSubComponentNavJS since ZenPacks.zenoss.vSphere not installed"
 
 def test_suite():
     """Return test suite for this module."""

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_usepowershell_datasource.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_usepowershell_datasource.py
@@ -26,7 +26,7 @@ from ZenPacks.zenoss.ZenPackLib.tests.ZPLTestHarness import ZPLTestHarness
 
 
 YAML_DOC = """
-name: ZenPacks.test.usePowershell
+name: ZenPacks.zenoss.Microsoft.Windows
 
 device_classes:
   /Server/Microsoft:
@@ -45,24 +45,15 @@ device_classes:
             parser: Auto
 """
 
-def win_shell_installed():
-    """Return True if ShellDataSource is installed"""
-    try:
-        from ZenPacks.zenoss.Microsoft.Windows.datasources.ShellDataSource import ShellDataSource
-    except ImportError:
-        pass
-    else:
-        return True
-    return False
 
-class TestZen25315(BaseTestCase):
+class TestUsePowershellDatasource(BaseTestCase):
     """
     "usePowershell" datasource option ignored in zenpacklib created ZenPacks (ZEN-25315)
     """
 
     def test_datasource_boolean(self):
-        if win_shell_installed():
-            z = ZPLTestHarness(YAML_DOC)
+        z = ZPLTestHarness(YAML_DOC)
+        if z.zenpack_installed():
             z.connect()
             # check properties on dummy template
             dcs = z.cfg.device_classes.get('/Server/Microsoft')
@@ -74,14 +65,15 @@ class TestZen25315(BaseTestCase):
                     'Datasource property (usePowershell) should be bool, got {}'.format(type(ds.usePowershell)))
             self.assertEquals(ds.usePowershell, False,
                     'Datasource property (usePowershell) should be False, got {}'.format(ds.usePowershell))
-
+        else:
+            print '\nSkipping test_integer_threshold since ZenPacks.zenoss.Microsoft.Windows not installed.'
 
 
 def test_suite():
     """Return test suite for this module."""
     from unittest import TestSuite, makeSuite
     suite = TestSuite()
-    suite.addTest(makeSuite(TestZen25315))
+    suite.addTest(makeSuite(TestUsePowershellDatasource))
     return suite
 
 if __name__ == "__main__":

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_violation_percent_integer.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_violation_percent_integer.py
@@ -24,18 +24,8 @@ from Products.ZenTestCase.BaseTestCase import BaseTestCase
 # zenpacklib Imports
 from ZenPacks.zenoss.ZenPackLib.tests.ZPLTestHarness import ZPLTestHarness
 
-def duration_installed():
-    '''Return True if Duration Threshold is installed'''
-    try:
-        from ZenPacks.zenoss.DurationThreshold.thresholds.DurationThreshold import DurationThreshold
-    except ImportError:
-        pass
-    else:
-        return True
-    return False
-
 YAML_DOC = """
-name: ZenPacks.community.TestDEFAULSonDatasource
+name: ZenPacks.zenoss.DurationThreshold
 device_classes:
   /Device:
     templates:
@@ -56,15 +46,15 @@ device_classes:
 """
 
 
-class TestZen24079(BaseTestCase):
+class TestDurationThresholdInteger(BaseTestCase):
     """Test fix for ZEN-24079
 
        Duration threshold has a problem where you cant set the violationPercent as integer
     """
 
     def test_integer_threshold(self):
-        if duration_installed():
-            z = ZPLTestHarness(YAML_DOC)
+        z = ZPLTestHarness(YAML_DOC)
+        if z.zenpack_installed():
             z.connect()
             self.assertTrue(z.check_templates_vs_yaml(), "Template objects do not match YAML")
             self.assertTrue(z.check_templates_vs_specs(), "Template objects do not match Spec")
@@ -75,14 +65,15 @@ class TestZen24079(BaseTestCase):
             for th in t.thresholds():
                 self.assertTrue(isinstance(th.violationPercentage, int),
                     'DurationThreshold property (violationPercentage) should be int, got {}'.format(type(th.violationPercentage)))
-
+        else:
+            print '\nSkipping test_integer_threshold since ZenPacks.zenoss.DurationThreshold not installed.'
 
 
 def test_suite():
     """Return test suite for this module."""
     from unittest import TestSuite, makeSuite
     suite = TestSuite()
-    suite.addTest(makeSuite(TestZen24079))
+    suite.addTest(makeSuite(TestDurationThresholdInteger))
     return suite
 
 if __name__ == "__main__":


### PR DESCRIPTION
Updated unit tests to handle running them in deployments with limited
zenpack availability.  Since some of the tests depend on the existence
of installed ZenPacks, these should be skipped if they are unavailable.

A new "zenpack_installed" method was added to ZPLTestHarness that
returns True if a given ZP is installed.  Various unit tests were
updated to run conditionally based on the zenpack_installed output.

Logging verbosity has also been reduced to eliminate most spurious
output during test execution.

Fixed traceback in ZPLCommand when in "is_valid_zenpack" method