### PR TITLE
Fix inaccurate datapoint YAML dump (ZEN-26593)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/Dumper.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/Dumper.py
@@ -107,7 +107,7 @@ class Dumper(yaml.Dumper):
         """
         from ..spec.RRDDatapointSpec import RRDDatapointSpec
         cls = obj.__class__
-        if isinstance(obj, RRDDatapointSpec) and obj.shorthand:
+        if isinstance(obj, RRDDatapointSpec) and obj.shorthand and obj.use_shorthand():
             # Special case- we allow for a shorthand in specifying datapoints
             # as specs as strings rather than explicitly as a map.
             return self.represent_str(str(obj.shorthand))


### PR DESCRIPTION
- Fixes ZEN-26593
- Corrects issue where datapoint aliases inadvertently removed from YAML
output
- Updated Dumper to use "use_shorthand" method in addition to existence
test
of 'shorthand' when outputting to YAML