### PR TITLE
Update Process Class Organizer export

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/libexec/ZPLCommand.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/libexec/ZPLCommand.py
@@ -533,11 +533,10 @@ class ZPLCommand(ZenScriptBase):
 
         processclasses = collections.defaultdict(dict)
         for processclassorg in [x for x in zenpack.packables() if x.meta_type == 'OSProcessOrganizer']:
-            pc_name = "/".join(processclassorg.getPrimaryUrlPath().split('/')[4:])
-            processclasses[pc_name] = ProcessClassOrganizerSpecParams.fromObject(processclassorg, remove=True)
+            pc_name = processclassorg.getDmdKey()
+            processclasses[pc_name] = ProcessClassOrganizerSpecParams.fromObject(processclassorg)
             for subclass in processclassorg.getSubOrganizers():
-                pc_name = "/".join(subclass.getPrimaryUrlPath().split('/')[4:])
-                # Remove = false because the removing the parent will remove the child # This is a performance optimization
-                processclasses[pc_name] = ProcessClassOrganizerSpecParams.fromObject(subclass, remove=False)
+                pc_name = subclass.getDmdKey()
+                processclasses[pc_name] = ProcessClassOrganizerSpecParams.fromObject(subclass)
 
         return processclasses


### PR DESCRIPTION
- Simplified organizer name to "getDmdKey" output
- Ensure that "remove" is always False to prevent root organizer removal
upon ZP removal, since there is no way to guarantee that a ZP "owns" the
Process Organizer class