### PR TITLE
Ensure proxy class instances displayed in GUI (ZPS-651) REVIEW ONLY

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/__init__.py
+++ b/ZenPacks/zenoss/ZenPackLib/__init__.py
@@ -57,3 +57,7 @@ class ZenPack(ZenPackBase):
         dest_path = zenPath('bin', 'zenpacklib')
         os.system('rm -f "%s"' % dest_path)
         LOG.info('Removing symlink {}'.format(dest_path))
+
+
+# Patch last to avoid import recursion problems.
+from ZenPacks.zenoss.ZenPackLib import patches

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassSpec.py
@@ -575,6 +575,13 @@ class ClassSpec(Spec):
                 return map.get('interface', IInfo)
         return IInfo
 
+    def get_facade_base(self):
+        """Return appropriate interfaces class"""
+        for cls, map in schema_map.items():
+            if self.is_a(cls):
+                return map.get('facade', None)
+        return None
+
     @property
     def is_device(self):
         """Return True if this class is a Device."""
@@ -773,7 +780,6 @@ class ClassSpec(Spec):
             self.resolved_bases,
             attributes)
 
-
     @property
     def model_class(self):
         """Return model class."""
@@ -956,6 +962,7 @@ class ClassSpec(Spec):
             GSM.registerAdapter(self.formbuilder_class, (self.info_class,), IFormBuilder)
         self.register_dynamicview_adapters()
         self.register_impact_adapters()
+        self.register_facade_types()
 
     def register_dynamicview_adapters(self):
         if not DYNAMICVIEW_INSTALLED:
@@ -996,6 +1003,13 @@ class ClassSpec(Spec):
                 BaseTriggers,
                 required=(self.model_class,),
                 provided=INodeTriggers)
+
+    def register_facade_types(self):
+        """Ensure this class gets listed in GUI elements"""
+        f_cls = self.get_facade_base()
+        if f_cls:
+            cls_name = '{}.{}'.format(self.symbol_name, self.name)
+            f_cls._types = tuple(set([f_cls._types] + [cls_name]))
 
     @property
     def containing_components(self):

--- a/ZenPacks/zenoss/ZenPackLib/lib/zuul.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/zuul.py
@@ -55,25 +55,28 @@ from Products.Zuul.interfaces.service import IServiceInfo
 from .info import HWComponentInfo
 from .interfaces import IHWComponentInfo
 
+from Products.Zuul.facades.processfacade import ProcessFacade
+from Products.Zuul.facades.servicefacade import ServiceFacade
+
 
 schema_map = {
-     Device: {'interface': IDeviceInfo, 'info': DeviceInfo},
-     Component: {'interface': IComponentInfo, 'info': ComponentInfo},
-     HWComponent: {'interface': IHWComponentInfo, 'info': HWComponentInfo},
-     HardwareComponent: {'interface': IHWComponentInfo, 'info': HWComponentInfo},
-     CPU: {'interface': ICPUInfo, 'info': CPUInfo},
-     ExpansionCard: {'interface': IExpansionCardInfo, 'info': ExpansionCardInfo},
-     Fan: {'interface': IFanInfo, 'info': FanInfo},
-     HardDisk: {'interface': IHWComponentInfo, 'info': HWComponentInfo},
-     PowerSupply: {'interface': IPowerSupplyInfo, 'info': PowerSupplyInfo},
-     TemperatureSensor: {'interface': ITemperatureSensorInfo, 'info': TemperatureSensorInfo},
-     OSComponent: {'interface': IComponentInfo, 'info': ComponentInfo},
-     FileSystem: {'interface': IFileSystemInfo, 'info': FileSystemInfo},
-     IpInterface: {'interface': IIpInterfaceInfo, 'info': IpInterfaceInfo},
-     IpRouteEntry: {'interface': IIpRouteEntryInfo, 'info': IpRouteEntryInfo},
-     OSProcess: {'interface': IOSProcessInfo, 'info': OSProcessInfo},
-     Service: {'interface': IServiceInfo, 'info': ServiceInfo},
-     IpService: {'interface': IIpServiceInfo, 'info': IpServiceInfo},
-     WinService: {'interface': IWinServiceInfo, 'info': WinServiceInfo},
+     Device: {'interface': IDeviceInfo, 'info': DeviceInfo, 'facade': None},
+     Component: {'interface': IComponentInfo, 'info': ComponentInfo, 'facade': None},
+     HWComponent: {'interface': IHWComponentInfo, 'info': HWComponentInfo, 'facade': None},
+     HardwareComponent: {'interface': IHWComponentInfo, 'info': HWComponentInfo, 'facade': None},
+     CPU: {'interface': ICPUInfo, 'info': CPUInfo, 'facade': None},
+     ExpansionCard: {'interface': IExpansionCardInfo, 'info': ExpansionCardInfo, 'facade': None},
+     Fan: {'interface': IFanInfo, 'info': FanInfo, 'facade': None},
+     HardDisk: {'interface': IHWComponentInfo, 'info': HWComponentInfo, 'facade': None},
+     PowerSupply: {'interface': IPowerSupplyInfo, 'info': PowerSupplyInfo, 'facade': None},
+     TemperatureSensor: {'interface': ITemperatureSensorInfo, 'info': TemperatureSensorInfo, 'facade': None},
+     OSComponent: {'interface': IComponentInfo, 'info': ComponentInfo, 'facade': None},
+     FileSystem: {'interface': IFileSystemInfo, 'info': FileSystemInfo, 'facade': None},
+     IpInterface: {'interface': IIpInterfaceInfo, 'info': IpInterfaceInfo, 'facade': None},
+     IpRouteEntry: {'interface': IIpRouteEntryInfo, 'info': IpRouteEntryInfo, 'facade': None},
+     OSProcess: {'interface': IOSProcessInfo, 'info': OSProcessInfo, 'facade': ProcessFacade},
+     IpService: {'interface': IIpServiceInfo, 'info': IpServiceInfo, 'facade': ServiceFacade},
+     WinService: {'interface': IWinServiceInfo, 'info': WinServiceInfo, 'facade': ServiceFacade},
+     Service: {'interface': IServiceInfo, 'info': ServiceInfo, 'facade': ServiceFacade},
      }
 

--- a/ZenPacks/zenoss/ZenPackLib/patches/__init__.py
+++ b/ZenPacks/zenoss/ZenPackLib/patches/__init__.py
@@ -1,0 +1,27 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from importlib import import_module
+
+
+def optional_import(module_name, patch_module_name):
+    '''
+    Import patch_module_name only if module_name is importable.
+    '''
+    try:
+        import_module(module_name)
+    except ImportError:
+        pass
+    else:
+        import_module(
+            '.{0}'.format(patch_module_name),
+            'ZenPacks.zenoss.ZenPackLib.patches')
+
+
+optional_import('Products.ZenModel', 'platform')

--- a/ZenPacks/zenoss/ZenPackLib/patches/platform.py
+++ b/ZenPacks/zenoss/ZenPackLib/patches/platform.py
@@ -1,0 +1,23 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+from Products.ZenUtils.Utils import monkeypatch
+
+# ZPS-561 Make sure our instances are included in GUI tabs
+from Products.Zuul.facades.processfacade import ProcessFacade
+from Products.Zuul.facades.servicefacade import ServiceFacade
+
+@property
+def get_instance_class(ob):
+    return ob._types
+
+ProcessFacade._types = ('Products.ZenModel.OSProcess.OSProcess')
+ProcessFacade._instanceClass = get_instance_class
+
+ServiceFacade._types = ('Products.ZenModel.Service.Service')
+ServiceFacade._instanceClass = get_instance_class


### PR DESCRIPTION
- Fixes ZPS-651 (and related ZPS-572)
- override facade _instanceClass property method so that it returns a
tuple of ZPL-derived classes in addition to the ZenModel base class.
- This alters the facade methods so that they return the expected
instances (components) in the various GUI elements
- Example is OSProcess-subclass instances in the Processes tab