### PR TITLE
Only create template if it does not exist or has changed

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -24,6 +24,14 @@ Backwards Incompatible Changes
 
 * zProperties will not be updated automatically on existing device classes.  These should be handled on a case basis by using migrate scripts.
 
+Release 2.0.2
+-------------
+
+Fixes
+
+* Only create a monitoring template if it changes or does not exist (ZPS-570)
+
+
 Release 2.0.1
 -------------
 


### PR DESCRIPTION
Fixes ZPS-570

* There is no need to delete and create a template if nothing
  has changed.