### PR TITLE
Add missing "-" to zenpack create command

### DIFF
--- a/docs/tutorial-http-api/create-zenpack.rst
+++ b/docs/tutorial-http-api/create-zenpack.rst
@@ -9,7 +9,7 @@ following steps. These commands should be run as the *zenoss* user.
 .. code-block:: bash
 
     cd /z
-    zenpacklib create ZenPacks.training.WeatherUnderground
+    zenpacklib --create ZenPacks.training.WeatherUnderground
 
 You should see output similar to the following. Most importantly that
 *zenpack.yaml* file is being created.


### PR DESCRIPTION
The command given to create a new ZenPack was missing the "--" before "create", causing the create to fail and print out the help message.