### PR TITLE
Add support for ZProperty label and description (ZPS-747)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ZPropertySpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ZPropertySpec.py
@@ -20,6 +20,8 @@ class ZPropertySpec(Spec):
             type_='string',
             default=None,
             category=None,
+            label=None,
+            description='',
             _source_location=None,
             zplog=None
             ):
@@ -33,6 +35,10 @@ class ZPropertySpec(Spec):
             :type default: ZPropertyDefaultValue
             :param category: ZProperty Category.  This is used for display/sorting purposes.
             :type category: str
+            :param label: ZProperty Label.  This is used for display/sorting purposes.
+            :type label: str
+            :param description: ZProperty Label.  This is used for display/sorting purposes.
+            :type description: str
         """
         super(ZPropertySpec, self).__init__(_source_location=_source_location)
         if zplog:
@@ -42,6 +48,8 @@ class ZPropertySpec(Spec):
         self.name = name
         self.type_ = type_
         self.category = category
+        self.label = label or name
+        self.description = description
 
         if default is None:
             self.default = {
@@ -62,3 +70,9 @@ class ZPropertySpec(Spec):
     def packZProperties(self):
         """Return packZProperties tuple for this zProperty."""
         return (self.name, self.default, self.type_)
+
+    @property
+    def packZProperties_data(self):
+        """Return packZProperties_data dict for this zProperty."""
+        return {self.name: {'label': self.label, 'description': self.description, 'type': self.type_}}
+

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ZenPackSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ZenPackSpec.py
@@ -555,8 +555,13 @@ class ZenPackSpec(Spec):
         packZProperties = [
             x.packZProperties for x in self.zProperties.itervalues()]
 
+        packZProperties_data = {}
+        for x in self.zProperties.itervalues():
+            packZProperties_data.update(x.packZProperties_data)
+
         attributes = {
-            'packZProperties': packZProperties
+            'packZProperties': packZProperties,
+            'packZProperties_data': packZProperties_data,
             }
 
         attributes['device_classes'] = self.device_classes


### PR DESCRIPTION
- Fixes ZPS-747
- Added "label" and "description" attributes to ZPropertySpec, which is
used to build the "packZProperties_data" attribute of the ZenPack class.
- new attributes listed in "label" and "description" columns of
Configuration Properties UI