### PR TITLE
Set EventClassMapping eventClassKey to name by default (ZPS-845)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/EventClassMappingSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/EventClassMappingSpec.py
@@ -51,7 +51,7 @@ class EventClassMappingSpec(Spec):
         self.klass_string = 'EventClassInst'
         self.eventclass_spec = eventclass_spec
         self.name = name
-        self.eventClassKey = eventClassKey
+        self.eventClassKey = eventClassKey or name
         self.sequence = sequence
         self.transform = transform
         self.rule = rule


### PR DESCRIPTION
- Fixes ZPS-845
- By default, the eventClassKey of a mapping is set to the name.
ZenPackLib should mirror this behavior