### PR TITLE
Generalize Graph Point Class

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/params/GraphPointSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/GraphPointSpecParams.py
@@ -10,10 +10,10 @@ from Acquisition import aq_base
 from Products.ZenModel.ThresholdGraphPoint import ThresholdGraphPoint
 from ..spec.GraphPointSpec import GraphPointSpec
 from .SpecParams import SpecParams
-
+from collections import OrderedDict
 
 class GraphPointSpecParams(SpecParams, GraphPointSpec):
-    def __init__(self, template_spec, name, **kwargs):
+    def __init__(self, graph_spec, name, **kwargs):
         SpecParams.__init__(self, **kwargs)
         self.name = name
 
@@ -25,12 +25,19 @@ class GraphPointSpecParams(SpecParams, GraphPointSpec):
         graphdefinition = aq_base(graphdefinition)
         sample_gp = graphpoint.__class__(graphpoint.id)
 
-        for propname in ('lineType', 'lineWidth', 'stacked', 'format',
-                         'legend', 'limit', 'rpn', 'cFunc', 'color', 'dpName'):
+        for propname in ('sequence', 'isThreshold', 'instruct_type', 'includeThresholds',
+                         'thresholdLegends'):
             if hasattr(sample_gp, propname):
                 setattr(self, '_%s_defaultvalue' % propname, getattr(sample_gp, propname))
             if getattr(graphpoint, propname, None) != getattr(sample_gp, propname, None):
                 setattr(self, propname, getattr(graphpoint, propname, None))
+
+        # any custom object properties not defined in the spec will go in extra_params
+        self.extra_params = OrderedDict()
+        ob_propnames = [x['id'] for x in graphpoint._properties if x['id'] not in cls.init_params]
+        for propname in ob_propnames:
+            if getattr(graphpoint, propname, None) != getattr(sample_gp, propname, None):
+                self.extra_params[propname] = getattr(graphpoint, propname, None)
 
         threshold_graphpoints = [x for x in graphdefinition.graphPoints() if isinstance(x, ThresholdGraphPoint)]
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/GraphDefinitionSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/GraphDefinitionSpec.py
@@ -18,6 +18,7 @@ class GraphDefinitionSpec(Spec):
             self,
             template_spec,
             name,
+            sequence=None,
             height=None,
             width=None,
             units=None,
@@ -34,7 +35,8 @@ class GraphDefinitionSpec(Spec):
             ):
         """
         Create a GraphDefinition Specification
-
+        :param sequence Order that this graph is rendered
+        :type sequence: int
         :param height TODO
         :type height: int
         :param width TODO
@@ -63,7 +65,7 @@ class GraphDefinitionSpec(Spec):
             self.LOG = zplog
         self.template_spec = template_spec
         self.name = name
-
+        self.sequence = sequence
         self.height = height
         self.width = width
         self.units = units
@@ -83,8 +85,8 @@ class GraphDefinitionSpec(Spec):
         graph = template.manage_addGraphDefinition(self.name)
         self.speclog.debug("adding graph")
 
-        if sequence:
-            graph.sequence = sequence
+        if sequence or self.sequence:
+            graph.sequence = self.sequence or sequence
         if self.height is not None:
             graph.height = self.height
         if self.width is not None:

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/GraphPointSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/GraphPointSpec.py
@@ -6,115 +6,142 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
+from Products.ZenModel.GraphDefinition import GraphDefinition
 from Products.ZenModel.GraphPoint import GraphPoint
 from Products.ZenModel.DataPointGraphPoint import DataPointGraphPoint
 from Products.ZenModel.ComplexGraphPoint import ComplexGraphPoint
+from Products.ZenModel.ThresholdGraphPoint import ThresholdGraphPoint
+from Products.ZenModel.DefGraphPoint import DefGraphPoint
+from Products.ZenModel.VdefGraphPoint import VdefGraphPoint
+from Products.ZenModel.CdefGraphPoint import CdefGraphPoint
+from Products.ZenModel.PrintGraphPoint import PrintGraphPoint
+from Products.ZenModel.GprintGraphPoint import GprintGraphPoint
+from Products.ZenModel.CommentGraphPoint import CommentGraphPoint
+from Products.ZenModel.VruleGraphPoint import VruleGraphPoint
+from Products.ZenModel.HruleGraphPoint import HruleGraphPoint
+from Products.ZenModel.LineGraphPoint import LineGraphPoint
+from Products.ZenModel.AreaGraphPoint import AreaGraphPoint
+from Products.ZenModel.TickGraphPoint import TickGraphPoint
+from Products.ZenModel.ShiftGraphPoint import ShiftGraphPoint
 from ..base.types import Color
 from .Spec import Spec
-
+from collections import OrderedDict
 
 class GraphPointSpec(Spec):
     """TODO."""
 
     def __init__(
             self,
-            template_spec,
-            name=None,
-            dpName=None,
-            lineType=None,
-            lineWidth=None,
-            stacked=None,
-            format=None,
-            legend=None,
-            limit=None,
-            rpn=None,
-            cFunc=None,
-            colorindex=None,
-            color=None,
+            graph_spec,
+            name,
+            sequence=None,
+            isThreshold=False,
+            instruct_type=None,
             includeThresholds=False,
             thresholdLegends=None,
+            extra_params={},
             _source_location=None,
             zplog=None
             ):
         """
         Create a GraphPoint Specification
-
-            :param dpName: TODO
-            :type dpName: str
-            :param lineType: TODO
-            :type lineType: str
-            :param lineWidth: TODO
-            :type lineWidth: int
-            :param stacked: TODO
-            :type stacked: bool
-            :param format: TODO
-            :type format: str
-            :param legend: TODO
-            :type legend: str
-            :param limit: TODO
-            :type limit: int
-            :param rpn: TODO
-            :type rpn: str
-            :param cFunc: TODO
-            :type cFunc: str
-            :param color: TODO
-            :type color: str
-            :param colorindex: TODO
-            :type colorindex: int
+            :param sequence: Order that this point is rendered
+            :type sequence: int
+            :param isThreshold: Whether or not this is a threshold
+            :type isThreshold: bool
+            :param instruct_type: Instruction for custom graph point type
+            :type instruct_type: str
             :param includeThresholds: TODO
             :type includeThresholds: bool
             :param thresholdLegends: map of {thresh_id: {legend: TEXT, color: HEXSTR}
             :type thresholdLegends: dict(str)
+            :param extra_params: Additional parameters that may be used by subclasses of GraphPoint
+            :type extra_params: ExtraParams
         """
         super(GraphPointSpec, self).__init__(_source_location=_source_location)
         if zplog:
             self.LOG = zplog
 
-        self.template_spec = template_spec
+        # basic GraphPoint params
+        self.graph_spec = graph_spec
         self.name = name
+        self.sequence = sequence
+        self.isThreshold = isThreshold
+        self.instruct_type = instruct_type
+        self.extra_params = extra_params
 
-        self.lineType = lineType
-        self.lineWidth = lineWidth
-        self.stacked = stacked
-        self.format = format
-        self.legend = legend
-        self.limit = limit
-        self.rpn = rpn
-        self.cFunc = cFunc
-        self.color = color
-        if color:
-            Color.LOG = self.LOG
-            self.color = Color(color)
+        # Whether to include related thresholds in the graph
         self.includeThresholds = includeThresholds
+        # dictionary of threshold legend attributes
         self.thresholdLegends = thresholdLegends
 
-        # Shorthand for datapoints that have the same name as their datasource.
-        if '_' not in dpName:
-            self.dpName = '{0}_{0}'.format(dpName)
+
+    # this probably should be moved to Spec.py and used throughout
+    @property
+    def extra_params(self):
+        """"""
+        return self._extra_params
+
+    @extra_params.setter
+    def extra_params(self, value):
+        self._extra_params = OrderedDict()
+        if value is None:
+            value = {}
+        for k, v in value.items():
+            setattr(self, k, v)
+            # set the extra param to the cleaned value
+            self._extra_params[k] = getattr(self, k)
+
+    @property
+    def lineType(self):
+        return self._lineType
+
+    @lineType.setter
+    def lineType(self, value):
+        value = value.upper()
+        valid_linetypes = [x[1] for x in DataPointGraphPoint.lineTypeOptions]
+        if value not in valid_linetypes:
+            raise ValueError("'{}' is not a valid graphpoint lineType. Valid lineTypes: {}".format(
+                                 value, ', '.join(valid_linetypes)))
+        self._lineType = value
+
+    @property
+    def colorindex(self):
+        """
+        Allow color to be specified by color_index instead of directly. This is
+        useful when you want to keep the normal progression of colors, but need
+        to add some DONTDRAW graphpoints for calculations.
+        """
+        return self._colorindex
+
+    @colorindex.setter
+    def colorindex(self, value):
+        if not isinstance(value, int):
+            raise ValueError("graphpoint colorindex must be numeric. (got {})".format(value))
+        self._colorindex = value
+        indexed = value % len(GraphPoint.colors)
+        self.color = GraphPoint.colors[indexed].lstrip('#')
+
+    @property
+    def color(self):
+        return self._color
+
+    @color.setter
+    def color(self, value):
+        if value:
+            Color.LOG = self.LOG
+        self._color = Color(value)
+
+    @property
+    def dpName(self):
+        return self._dpName
+
+    @dpName.setter
+    def dpName(self, value):
+        if value and len(value.split('_')) == 1:
+            self._dpName = '{0}_{0}'.format(value)
         else:
-            self.dpName = dpName
-
-        # Allow color to be specified by color_index instead of directly. This is
-        # useful when you want to keep the normal progression of colors, but need
-        # to add some DONTDRAW graphpoints for calculations.
-        self.colorindex = colorindex
-        if colorindex:
-            try:
-                colorindex = int(colorindex) % len(GraphPoint.colors)
-            except (TypeError, ValueError):
-                raise ValueError("graphpoint colorindex must be numeric.")
-
-            self.color = GraphPoint.colors[colorindex].lstrip('#')
-
-        # Validate lineType.
-        if lineType:
-            valid_linetypes = [x[1] for x in ComplexGraphPoint.lineTypeOptions]
-
-            if lineType.upper() in valid_linetypes:
-                self.lineType = lineType.upper()
-            else:
-                raise ValueError("'%s' is not a valid graphpoint lineType. Valid lineTypes: %s" % (
-                                 lineType, ', '.join(valid_linetypes)))
+            self._dpName = value
 
     @property
     def thresholdLegends(self):
@@ -137,32 +164,59 @@ class GraphPointSpec(Spec):
             self._thresholdLegends[id]['legend'] = data.get('legend')
             self._thresholdLegends[id]['color'] = data.get('color')
 
+    @property
+    def instruct_type(self):
+        return self._instruct_type
+
+    @instruct_type.setter
+    def instruct_type(self, value):
+        self._instruct_type = value
+        if value:
+            instruct_types = self.get_instruct_types()
+            if value not in instruct_types:
+                raise ValueError("{} is an invalid instruction type. Valid types: {}".format(
+                             value, ', '.join(instruct_types.keys())))
+
+    def get_instruct_types(self):
+        """return dictionary of instructions and related classes"""
+        ob = GraphDefinition('tmp')
+        return dict([(x[1], eval(x[0])) for x in ob.getGraphPointOptions()])
+
+    def get_point_type(self):
+        """return appropriate graphpoint subclass"""
+        # if types not provided, assume it's the default or a threshold
+        if not self.instruct_type:
+            if not self.isThreshold:
+                return DataPointGraphPoint
+            else:
+                return ThresholdGraphPoint
+        else:
+            graphpoint_types = self.get_instruct_types()
+            return graphpoint_types.get(self.instruct_type, DataPointGraphPoint)
+
+    # probably should be moved to Spec
+    def update_instance_attributes(self, ob):
+        """
+            Set extra_params attributes on created objects, 
+            preferring any property setter method override versions
+        """
+        for k, v in self.extra_params.items():
+            setattr(ob, k, getattr(self, k, v))
+
     def create(self, graph_spec, graph, sequence=None):
-        graphpoint = graph.createGraphPoint(DataPointGraphPoint, self.name)
-        self.speclog.debug("adding graphpoint")
+        type_ = self.get_point_type()
+        if not type_:
+            raise ValueError("{} - {} cannot be created. Valid types: {}" % (
+                        graph_spec.name, self.name, ', '.join(self.get_instruct_types().keys())))
 
-        graphpoint.dpName = self.dpName
+        graphpoint = graph.createGraphPoint(type_, self.name)
 
-        if sequence:
-            graphpoint.sequence = sequence
-        if self.lineType is not None:
-            graphpoint.lineType = self.lineType
-        if self.lineWidth is not None:
-            graphpoint.lineWidth = self.lineWidth
-        if self.stacked is not None:
-            graphpoint.stacked = self.stacked
-        if self.format is not None:
-            graphpoint.format = self.format
-        if self.legend is not None:
-            graphpoint.legend = self.legend
-        if self.limit is not None:
-            graphpoint.limit = self.limit
-        if self.rpn is not None:
-            graphpoint.rpn = self.rpn
-        if self.cFunc is not None:
-            graphpoint.cFunc = self.cFunc
-        if self.color is not None:
-            graphpoint.color = str(self.color)
+        self.update_instance_attributes(graphpoint)
+
+        # threshold sequence is set to -1 by default
+        if not self.isThreshold:
+            if sequence or self.sequence:
+                graphpoint.sequence = self.sequence or sequence 
 
         if self.includeThresholds:
             thresh_gps = graph.addThresholdsForDataPoint(self.dpName)

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDTemplateSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDTemplateSpec.py
@@ -81,9 +81,11 @@ class RRDTemplateSpec(Spec):
         # check graph point references
         for g_name, g_spec in self.graphs.items():
             for gp_name, gp_spec in g_spec.graphpoints.items():
+                if not hasattr(gp_spec, 'dpName'):
+                    continue
                 self.check_ds_dp_names(gp_name,
                                        'Graph Point',
-                                       set([gp_spec.dpName]),
+                                       set([str(gp_spec.dpName)]),
                                        ds_dp_names)
 
     def get_dp_names(self):

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_color_validation.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_color_validation.py
@@ -64,20 +64,20 @@ device_classes:
           Graph:
             graphpoints:
               A:
+                color: '403200'
                 dpName: test_a
-                color: '007700'
               B:
-                dpName: test_b
                 color: FF3300
+                dpName: test_b
               C:
-                dpName: test_c
                 color: 0000BB
+                dpName: test_c
               D:
+                color: '0'
                 dpName: test_c
-                color: '000000'
               E:
-                dpName: test_c
                 color: FFF002
+                dpName: test_c
               F:
                 dpName: test_c
 """

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_template_modify.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_template_modify.py
@@ -276,7 +276,7 @@ device_classes:
                 rpn: 100,/
 """
 
-DIFF = "--- \n+++ \n@@ -4,8 +4,8 @@\n   CPU Utilization:\n     dsnames: [ssCpuRawIdle_ssCpuRawIdle]\n     eventClass: /Perf/CPU\n-    minval: '2'\n-    escalateCount: 5\n+    minval: '3'\n+    escalateCount: 7\n datasources:\n   memBuffer:\n     type: SNMP\n@@ -124,7 +124,6 @@\n     graphpoints:\n       laLoadInt5:\n         dpName: laLoadInt5_laLoadInt5\n-        lineType: AREA\n         format: '%0.2lf'\n         rpn: 100,/\n \n"
+DIFF = "--- \n+++ \n@@ -4,8 +4,8 @@\n   CPU Utilization:\n     dsnames: [ssCpuRawIdle_ssCpuRawIdle]\n     eventClass: /Perf/CPU\n-    minval: '2'\n-    escalateCount: 5\n+    minval: '3'\n+    escalateCount: 7\n datasources:\n   memBuffer:\n     type: SNMP\n@@ -126,7 +126,6 @@\n     units: load\n     graphpoints:\n       laLoadInt5:\n-        lineType: AREA\n         format: '%0.2lf'\n         rpn: 100,/\n         dpName: laLoadInt5_laLoadInt5\n"
 
 
 class TestTemplateModified(ZPLTestBase):


### PR DESCRIPTION
GraphPointSpec has been generalized with most parameters moved to
extra_params.  This allows the spec to be used in a similar fashion to
RRDDatasourceSpec, allowing attribute overloading via the extra_params
attribute.

- ThresholdDataPoints can now be created directly in YAML by setting
"isThreshold" to True
- Comment and other types can be generated via use of the instruct_type
- GraphPointSpec accepts "sequence" paramter
- Change is backwards compatible with existing YAML
- Updated unit tests