### PR TITLE
Remove zProperty label and description support

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ZPropertySpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ZPropertySpec.py
@@ -20,8 +20,6 @@ class ZPropertySpec(Spec):
             type_='string',
             default=None,
             category=None,
-            label=None,
-            description='',
             _source_location=None,
             zplog=None
             ):
@@ -35,10 +33,6 @@ class ZPropertySpec(Spec):
             :type default: ZPropertyDefaultValue
             :param category: ZProperty Category.  This is used for display/sorting purposes.
             :type category: str
-            :param label: ZProperty Label.  This is used for display/sorting purposes.
-            :type label: str
-            :param description: ZProperty Label.  This is used for display/sorting purposes.
-            :type description: str
         """
         super(ZPropertySpec, self).__init__(_source_location=_source_location)
         if zplog:
@@ -48,8 +42,6 @@ class ZPropertySpec(Spec):
         self.name = name
         self.type_ = type_
         self.category = category
-        self.label = label or name
-        self.description = description
 
         if default is None:
             self.default = {
@@ -70,8 +62,3 @@ class ZPropertySpec(Spec):
     def packZProperties(self):
         """Return packZProperties tuple for this zProperty."""
         return (self.name, self.default, self.type_)
-
-    @property
-    def packZProperties_data(self):
-        """Return packZProperties_data dict for this zProperty."""
-        return {self.name: {'label': self.label, 'description': self.description, 'type': self.type_}}

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ZenPackSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ZenPackSpec.py
@@ -555,13 +555,8 @@ class ZenPackSpec(Spec):
         packZProperties = [
             x.packZProperties for x in self.zProperties.itervalues()]
 
-        packZProperties_data = {}
-        for x in self.zProperties.itervalues():
-            packZProperties_data.update(x.packZProperties_data)
-
         attributes = {
             'packZProperties': packZProperties,
-            'packZProperties_data': packZProperties_data,
             }
 
         attributes['device_classes'] = self.device_classes

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -27,10 +27,6 @@ Backwards Incompatible Changes
 Release 2.0.2
 -------------
 
-Features
-
-* Add support for ZProperty label and description (ZPS-747, ZPS-819)
-
 Fixes
 
 * Only create a monitoring template if it changes or does not exist (ZPS-570)


### PR DESCRIPTION
- As new features, these are inappropriate for a hotfix release, and
will be exclusive to the 2.1 release of ZenPackLib