### PR TITLE
Remove mutable function defaults

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/utils.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/utils.py
@@ -111,8 +111,10 @@ def load_yaml_single(yaml_doc, useLoader=True, loader=Loader):
         return yaml.load(yaml_doc)
 
 
-def get_merged_docs(docs=[]):
+def get_merged_docs(docs=None):
     '''return recursively merged dictionnary'''
+    if docs is None:
+        docs = []
     def merge_dict(target, source):
         for k, v in source.items():
             if (k in target and isinstance(target[k], dict)
@@ -293,7 +295,7 @@ def sort_yaml_data(data):
     return ordered
 
 
-def writeDataToFile(keywords=[]):
+def writeDataToFile(keywords=None):
     '''
     This is a decorator that will save arguments sent to a function.
     It will write to the /tmp directory using the class name, method name
@@ -330,6 +332,8 @@ def writeDataToFile(keywords=[]):
 
     $ export ZPL_DUMP_DATA=1; python foo.py; unset ZPL_DUMP_DATA
     '''
+    if keywords is None:
+        keywords = []
     def wrap(f):
         def dumper(self, *args, **kwargs):
             import os

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/ClassSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/ClassSpecParams.py
@@ -14,7 +14,7 @@ from ..spec.ClassSpec import ClassSpec
 
 
 class ClassSpecParams(SpecParams, ClassSpec):
-    def __init__(self, zenpack_spec, name, base=None, properties=None, relationships=None, impact_triggers=None, monitoring_templates=[], **kwargs):
+    def __init__(self, zenpack_spec, name, base=None, properties=None, relationships=None, impact_triggers=None, monitoring_templates=None, **kwargs):
         SpecParams.__init__(self, **kwargs)
         self.name = name
 
@@ -23,6 +23,8 @@ class ClassSpecParams(SpecParams, ClassSpec):
         else:
             self.base = (base,)
 
+        if monitoring_templates is None:
+            monitoring_templates = []
         if isinstance(monitoring_templates, (tuple, list, set)):
             self.monitoring_templates = list(monitoring_templates)
         else:

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDThresholdSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDThresholdSpec.py
@@ -18,7 +18,7 @@ class RRDThresholdSpec(Spec):
             template_spec,
             name,
             type_='MinMaxThreshold',
-            dsnames=[],
+            dsnames=None,
             eventClass=None,
             severity=None,
             enabled=None,
@@ -50,6 +50,8 @@ class RRDThresholdSpec(Spec):
 
         self.name = name
         self.template_spec = template_spec
+        if dsnames is None:
+            dsnames = []
         self.dsnames = dsnames
         self.eventClass = eventClass
         Severity.LOG = self.LOG

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/Spec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/Spec.py
@@ -329,7 +329,9 @@ class Spec(object):
 
         return params
 
-    def __eq__(self, other, ignore_params=[]):
+    def __eq__(self, other, ignore_params=None):
+        if ignore_params is None:
+            ignore_params = []
         if type(self) != type(other):
             return False
 

--- a/ZenPacks/zenoss/ZenPackLib/tests/ZPLTestBase.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/ZPLTestBase.py
@@ -105,8 +105,10 @@ class ZPLTestCommand(ZPLTestBase):
 
         return out
 
-    def get_cmd_success(self, cmd, vars={}):
+    def get_cmd_success(self, cmd, vars=None):
         """execute a command and assert success"""
+        if vars is None:
+            vars = {}
         p, out, err = self.get_cmd_output(cmd, vars)
         self.log.debug("out=%s, err=%s", out, err)
         msg = 'Command "{}" failed with error:\n  {}'.format(cmd, err)
@@ -114,8 +116,10 @@ class ZPLTestCommand(ZPLTestBase):
         return out
 
     @classmethod
-    def get_cmd_output(cls, cmd, vars={}):
+    def get_cmd_output(cls, cmd, vars=None):
         """execute a command and return the output"""
+        if vars is None:
+            vars = {}
         cls.log.info(" ".join(cmd))
         env = dict(os.environ)
         env.update(vars)


### PR DESCRIPTION
Replaced all mutable function defaults with None and updated each
function to handle case where argument equals None.  This was done to
prevent difficult to trace errors and unexpected behavior.