### PR TITLE
Preserve order when loading from multiple YAML files (DO NOT MERGE)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
@@ -290,7 +290,8 @@ class ZenPack(ZenPackBase):
         proto_yaml = yaml.dump(specparam, Dumper=Dumper)
         return self.get_yaml_diff(object_yaml, proto_yaml)
 
-    def get_yaml_diff(self, yaml_existing, yaml_new):
+    @classmethod
+    def get_yaml_diff(cls, yaml_existing, yaml_new):
         """Return diff between YAML files"""
         if yaml_existing != yaml_new:
             lines_existing = [x + '\n' for x in yaml_existing.split('\n')]

--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/utils.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/utils.py
@@ -12,7 +12,7 @@ import yaml
 import time
 from .ZenPackLibLog import DEFAULTLOG
 from .Dumper import Dumper
-from .Loader import Loader
+from .Loader import Loader, BasicLoader
 import inspect
 
 # adding these so that yaml.Loader can handle !ZenPackSpec tag
@@ -104,11 +104,11 @@ def load_yaml_single(yaml_doc, useLoader=True, loader=Loader):
     if os.path.isfile(yaml_doc):
         if useLoader:
             return yaml.load(file(yaml_doc, 'r'), Loader=loader)
-        return yaml.load(file(yaml_doc, 'r'))
+        return yaml.load(file(yaml_doc, 'r'), Loader=BasicLoader)
     else:
         if useLoader:
             return yaml.load(yaml_doc, Loader=loader)
-        return yaml.load(yaml_doc)
+        return yaml.load(yaml_doc, Loader=BasicLoader)
 
 
 def get_merged_docs(docs=None):
@@ -153,7 +153,7 @@ def optimize_yaml(yaml_doc):
     # load original yaml back as a Python dictionary
     data = load_yaml_single(orig_yaml, useLoader=False)
     # optimized output
-    optimized_yaml = get_optimized_yaml(data)
+    optimized_yaml = get_optimized_yaml(data, sorted=True)
     # new load
     valid = compare_zenpackspecs(orig_yaml, optimized_yaml)
     if not valid:
@@ -201,14 +201,17 @@ def dict_compare(d1, d2):
     DEFAULTLOG.warn('MODIFIED: {}'.format(modified))
 
 
-def get_optimized_yaml(data):
+def get_optimized_yaml(data, sorted=False):
     """
         return optimized YAML representing ZenPackSpec
     """
     # set DEFAULTS throughout
     descend_defaults(data)
     # sort
-    ordered = sort_yaml_data(data)
+    if sorted:
+        ordered = sort_yaml_data(data)
+    else:
+        ordered = data
     # optimized output
     return yaml.dump(ordered, default_flow_style=False, Dumper=Dumper).replace('!!map', '')
 

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_load_dir.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_load_dir.py
@@ -22,6 +22,7 @@ from ZenPacks.zenoss.ZenPackLib import zenpacklib
 import yaml
 from ZenPacks.zenoss.ZenPackLib.lib.helpers.Dumper import Dumper
 from ZenPacks.zenoss.ZenPackLib.lib.helpers.utils import compare_zenpackspecs
+from ZenPacks.zenoss.ZenPackLib.lib.base.ZenPack import ZenPack
 
 # Zenoss Imports
 import Globals  # noqa
@@ -730,9 +731,9 @@ class TestDirectoryLoad(BaseTestCase):
         dir_yaml = yaml.dump(cfg_dir.specparams, Dumper=Dumper)
 
         compare_equals = compare_zenpackspecs(whole_yaml, dir_yaml)
-
-        self.assertTrue(compare_equals, 
-                        'YAML Multiple file test failed')
+        diff = ZenPack.get_yaml_diff(whole_yaml, dir_yaml)
+        self.assertTrue(compare_equals,
+                        'YAML Multiple file test failed:\n{}'.format(diff))
 
 
 


### PR DESCRIPTION
- added BasicLoader class to handle OrdereDict and sequenced data
- subclassed ZPL Loader from BasicLoader
- load_yaml_single now uses BasicLoader if "useLoader" is False
- added "sorted" boolean argument to "get_optimized_yaml"
- restricted "sorting" behavior to "optimize_yaml" method (used by
--optimized flag)
- changed ZenPack "get_yaml_diff" to classmethod for convenience
- updated test_load_dir to print out YAML diff when failing