### PR TITLE
Preserve order in ZenPackSpec YAML exports

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/loaders.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/loaders.py
@@ -36,6 +36,9 @@ class OrderedLoader(yaml.Loader):
             u'tag:yaml.org,2002:omap',
             type(self).dict_constructor)
 
+        self.add_constructor(u'!ZenPackSpec', type(self).dict_constructor)
+        self.add_path_resolver(u'!ZenPackSpec', [])
+
     def dict_constructor(self, node):
         """constructor for OrderedDict"""
         return OrderedDict(self.construct_pairs(node))


### PR DESCRIPTION
- OrderedLoader updated so that dumped YAML maintains order
- compare_zenpackspecs method updated for improved accuracy
- optimize_yaml updated for improved accuracy