### PR TITLE
Fix setting zProp values on parent device classes

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
@@ -13,6 +13,7 @@ import difflib
 import time
 import sys
 
+from Acquisition import aq_base
 from Products.ZenModel.ZenPack import ZenPack as ZenPackBase
 from ..helpers.Dumper import Dumper
 from ..helpers.ZenPackLibLog import ZenPackLibLog, new_log
@@ -59,30 +60,7 @@ class ZenPack(ZenPackBase):
 
     def install(self, app):
         self.createZProperties(app)
-
-        # create device classes and set zProperties on them
-        for dcname, dcspec in self.device_classes.iteritems():
-            if dcspec.create:
-                dcObject = self.create_device_class(app, dcspec)
-            else:
-                try:
-                    dcObject = self.dmd.Devices.getOrganizer(dcspec.path)
-                except KeyError:
-                    self.LOG.warn('Device Class ({}) not found'.format(dcspec.path))
-                    dcObject = None
-            # if device class has description and protocol, register a devtype
-
-            if dcObject and dcspec.description and dcspec.protocol:
-                try:
-                    if (dcspec.description, dcspec.protocol) not in dcObject.devtypes:
-                        self.LOG.info('Registering devtype for {}: {} ({})'.format(dcObject,
-                                                                                   dcspec.protocol,
-                                                                                   dcspec.description))
-                        dcObject.register_devtype(dcspec.description, dcspec.protocol)
-                except Exception as e:
-                    self.LOG.warn('Error registering devtype for {}: {} ({})'.format(dcObject,
-                                                                                     dcspec.protocol,
-                                                                                     e))
+        self.create_device_classes(app)
 
         # Load objects.xml now
         super(ZenPack, self).install(app)
@@ -299,27 +277,81 @@ class ZenPack(ZenPackBase):
             return ''.join(difflib.unified_diff(lines_existing, lines_new))
         return None
 
+    def create_device_classes(self, app):
+        """Create device classes. Set their zProperties and devtypes."""
+        for dcname in sorted(self.device_classes):
+            # Device classes must be created in alphanumeric order to
+            # prevent children from implicitly creating their parents. When
+            # children implicitly create their parents, zProperty values
+            # won't get set on the parents.
+            dcspec = self.device_classes[dcname]
+
+            if dcspec.create:
+                self.create_device_class(app, dcspec)
+            else:
+                try:
+                    self.dmd.Devices.getOrganizer(dcspec.path)
+                except KeyError:
+                    self.LOG.warn(
+                        "Device Class (%s) not found",
+                        dcspec.path)
+
     def create_device_class(self, app, dcspec):
-        """Create and return a DeviceClass"""
-        exists = False
+        """Create and return a DeviceClass. Set zProperties and devtypes.
+
+        zProperties and devtypes will only be set if the device class
+        doesn't already exist. This is done to prevent overwriting of user
+        customizations on upgrade.
+
+        """
         try:
             dcObject = app.dmd.Devices.getOrganizer(dcspec.path)
-            exists = True
         except KeyError:
-            self.LOG.info('Creating DeviceClass {}'.format(dcspec.path))
+            self.LOG.debug("Creating %s device class", dcspec.path)
             dcObject = app.dmd.Devices.createOrganizer(dcspec.path)
+        else:
+            self.LOG.debug(
+                "Existing %s device class - not overwriting properties",
+                dcspec.path)
 
+            return dcObject
+
+        # Set zProperties.
         for zprop, value in dcspec.zProperties.iteritems():
-            # Avoid setting zProperties on an existing device class
-            if exists:
-                if value != getattr(dcObject, zprop, None):
-                    self.LOG.debug('Not setting "{}" to "{}" on existing device class ({})'.format(zprop, value, dcspec.path))
-                continue
             if dcObject.getPropertyType(zprop) is None:
-                self.LOG.error("Unable to set zProperty {} on {} (undefined zProperty)".format(zprop, dcspec.path))
+                self.LOG.error(
+                    "Unable to set zProperty %s on %s (undefined zProperty)",
+                    zprop, dcspec.path)
             else:
-                self.LOG.info('Setting zProperty {} on {}'.format(zprop, dcspec.path))
-                dcObject.setZenProperty(zprop, value)
+                self.LOG.debug(
+                    "Setting zProperty %s to %r on %s",
+                    zprop, value, dcspec.path)
+
+                # We want to explicitly set the value even if it's the same as
+                # what's being acquired. This is why aq_base is required.
+                aq_base(dcObject).setZenProperty(zprop, value)
+
+        # Register devtype.
+        if dcObject and dcspec.description and dcspec.protocol:
+            self.LOG.debug(
+                "Registering devtype for %s: %s (%s)",
+                dcspec.path,
+                dcspec.protocol,
+                dcspec.description)
+
+            try:
+                # We want to explicitly set the value even if it's the same as
+                # what's being acquired. This is why aq_base is required.
+                aq_base(dcObject).register_devtype(
+                    dcspec.description,
+                    dcspec.protocol)
+            except Exception as e:
+                self.LOG.warn(
+                    "Error registering devtype for %s: %s (%s)",
+                    dcspec.path,
+                    dcspec.protocol,
+                    e)
+
         return dcObject
 
     def remove_device_class(self, app, dcspec):

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_installed_zenpacks.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_installed_zenpacks.py
@@ -10,6 +10,7 @@
 ##############################################################################
 """Test this version of ZenPackLib against relevant installed ZenPacks"""
 
+import importlib
 import os
 from ZenPacks.zenoss.ZenPackLib.tests.ZPLTestHarness import ZPLTestHarness
 from ZenPacks.zenoss.ZenPackLib.tests.ZPLTestBase import ZPLTestBase
@@ -19,19 +20,15 @@ class TestInstalledZenPacks(ZPLTestBase):
     """Test this version of ZenPackLib against relevant installed ZenPacks"""
 
     use_dmd = True
-    files = []
-
-    def afterSetUp(self):
-        super(TestInstalledZenPacks, self).afterSetUp()
-        for z in self.z.dmd.ZenPackManager.packs():
-            if not isinstance(z, ZenPack):
-                continue
-            self.files.append(z.path())
 
     def test_installed_zenpacks(self):
-        for file in self.files:
-            self.z = ZPLTestHarness(file, verbose=False)
-            self.check_zenpack(self.z)
+        for zenpack in self.z.dmd.ZenPackManager.packs():
+            if not isinstance(zenpack, ZenPack):
+                continue
+
+            zenpack_module = importlib.import_module(zenpack.id)
+            cfg = getattr(zenpack_module, "CFG", None)
+            self.check_zenpack(ZPLTestHarness(cfg, verbose=False))
 
     def check_zenpack(self, z):
         self.assertTrue(z.check_properties(), "Property testing failed for {}".format(z.cfg.name))

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,7 @@ Release 2.0.3
 Fixes
 
 * Preserve ordering when loading multiple YAML files (ZPS-921)
+* Fix setting of zProperty values when loading multiple YAML files. (ZPS-925)
 
 
 Release 2.0.2


### PR DESCRIPTION
When multiple nested device classes were split into separate YAML files you
could get into a situation where the child device classes were created
before their parents. This caused zProperty values to not be set on the
parent device classes because when it came time to set them, it appeared
that the parent device class had already been created.

This change fixes the problem by creating device classes in order. This has
the result of making sure that parent device classes are always created
before their children.

Fixes ZEN-925.