### PR TITLE
Add Property class to handle Properties and ZProperties

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/base/types.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/base/types.py
@@ -1,6 +1,69 @@
 from ..helpers.ZenPackLibLog import DEFAULTLOG as LOG
 import string
+from DateTime import DateTime
 from Products.ZenRelations.RelSchema import ToMany, ToManyCont, ToOne
+
+
+class Property(object):
+    """Represent _properties entry"""
+    LOG = LOG
+    _property_map = {'string': {'default': '', 'class': str, 'type': 'str'},
+                     'password': {'default': '', 'class': str, 'type': 'str'},
+                     'boolean': {'default': False, 'class': bool, 'type': 'bool'},
+                     'int': {'default': None, 'class': int, 'type': 'int'},
+                     'float': {'default': None, 'class': float, 'type': 'float'},
+                     'long': {'default': None, 'class': long, 'type': 'long'},
+                     'date': {'default': DateTime('1970/01/01 00:00:00 UTC'), 'class': DateTime, 'type': 'date'},
+                     'lines': {'default': [], 'class': list, 'type': 'list(str)'},
+                     'text': {'default': None, 'class': str, 'type': 'str'},
+                    }
+
+    def __init__(self, name, type_='string', default=None):
+        self.name = name
+        self.type_ = type_
+        self.default = default
+
+    @property
+    def default(self):
+        return self._default
+
+    @default.setter
+    def default(self, value):
+        if value is not None:
+            try:
+                self._default = self.property_class(value)
+            except Exception as e:
+                # This appears to be occurring for int properties since they seem to acquire '' for a default
+                # probably from the Spec or SpecParam init_params
+                if self.type_ != 'int':
+                    LOG.warn('Error setting "{}" default ({}): {}'.format(self.name, value, e))
+                self._default = self.default_value
+        else:
+            self._default = self.default_value
+
+    @classmethod
+    def get_default_value(cls, type_):
+        return cls._property_map.get(type_, {}).get('default', None)
+
+    @property
+    def default_value(self):
+        return self.get_default_value(self.type_)
+
+    @classmethod
+    def get_property_type(cls, type_):
+        return cls._property_map.get(type_, {}).get('type', 'str')
+
+    @property
+    def property_type(self):
+        return self.get_property_type(self.type_)
+
+    @classmethod
+    def get_property_class(cls, type_):
+        return cls._property_map.get(type_, {}).get('class', str)
+
+    @property
+    def property_class(self):
+        return self.get_property_class(self.type_)
 
 
 class Relationship(str):

--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/Dumper.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/Dumper.py
@@ -11,21 +11,9 @@ import re
 from yaml.representer import SafeRepresenter
 from collections import OrderedDict
 from .ZenPackLibLog import DEFAULTLOG
-
-
-def get_zproperty_type(z_type):
-    """
-        For zproperties, the actual data type of a default value
-        depends on the defined type of the zProperty.
-    """
-    map = {'boolean': 'bool',
-           'int': 'int',
-           'float': 'float',
-           'string': 'str',
-           'password': 'str',
-           'lines': 'list(str)'
-    }
-    return map.get(z_type, 'str')
+from datetime import date, datetime
+from DateTime import DateTime
+from ..base.types import Property
 
 
 class Dumper(yaml.Dumper):
@@ -152,7 +140,7 @@ class Dumper(yaml.Dumper):
             if type_ == 'ZPropertyDefaultValue':
                 # For zproperties, the actual data type of a default value
                 # depends on the defined type of the zProperty.
-                type_ = get_zproperty_type(obj.type_)
+                type_ = Property.get_property_type(obj.type_)
 
             yaml_param = self.represent_str(p_data.get('yaml_param'))
             try:
@@ -196,6 +184,11 @@ class Dumper(yaml.Dumper):
             node_value = self.represent_data(item_value)
             value.append((node_key, node_value))
         return yaml.MappingNode(u'tag:yaml.org,2002:map', value)
+
+    def represent_DateTime(self, data):
+        """represent DateTime object"""
+        dt = data.asdatetime()
+        return self.represent_data(dt)
 
     def represent_severity(self, data):
         """represent Severity"""
@@ -305,6 +298,9 @@ Dumper.add_representer(ProcessClassOrganizerSpecParams, Dumper.represent_spec)
 Dumper.add_representer(ProcessClassSpecParams, Dumper.represent_spec)
 Dumper.add_representer(ImpactTriggerSpecParams, Dumper.represent_spec)
 Dumper.add_representer(LinkProviderSpecParams, Dumper.represent_spec)
+Dumper.add_representer(date, SafeRepresenter.represent_date)
+Dumper.add_representer(datetime, SafeRepresenter.represent_datetime)
+Dumper.add_representer(DateTime, Dumper.represent_DateTime)
 # representers for custom types
 from ..base.types import Color, Severity
 Dumper.add_representer(Color, SafeRepresenter.represent_str)

--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/Loader.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/Loader.py
@@ -13,6 +13,7 @@ import sys
 import importlib
 import keyword
 from collections import OrderedDict
+from DateTime import DateTime
 from ..functions import ZENOSS_KEYWORDS, JS_WORDS, relname_from_classname, find_keyword_cls
 from .ZenPackLibLog import ZPLOG, DEFAULTLOG
 from ..base.types import Severity
@@ -33,6 +34,9 @@ class Loader(yaml.Loader):
     def dict_constructor(self, node):
         """constructor for OrderedDict"""
         return OrderedDict(self.construct_pairs(node))
+
+    def construct_DateTime(self, node):
+        return DateTime(node.value)
 
     def construct_severity(self, node):
         value = node.value
@@ -166,6 +170,8 @@ class Loader(yaml.Loader):
                     yaml_value = self.construct_python_str(value_node)
                 elif expected_type == 'float' and not isinstance(yaml_value, float):
                     yaml_value = self.construct_yaml_float(value_node)
+                elif expected_type == 'date' and not isinstance(yaml_value, DateTime):
+                    yaml_value = self.construct_DateTime(value_node)
                 elif expected_type.startswith("dict(SpecsParameter("):
                     m = re.match('^dict\(SpecsParameter\((.*)\)\)$', expected_type)
                     if m:
@@ -462,5 +468,6 @@ class Loader(yaml.Loader):
 
 Loader.add_constructor(u'tag:yaml.org,2002:seq', Loader.construct_sequence)
 Loader.add_constructor(u'tag:yaml.org,2002:map', Loader.dict_constructor)
+Loader.add_constructor(u'tag:yaml.org,2002:timestamp', Loader.construct_DateTime)
 Loader.add_constructor(u'!ZenPackSpec', Loader.construct_zenpackspec)
 yaml.add_path_resolver(u'!ZenPackSpec', [], Loader=Loader)

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassPropertySpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassPropertySpec.py
@@ -9,6 +9,7 @@
 from Products.Zuul.form import schema
 from Products.Zuul.utils import ZuulMessageFactory as _t
 from Products.Zuul.infos import ProxyProperty
+from ..base.types import Property
 from ..helpers.OrderAndValue import OrderAndValue
 from .Spec import Spec, MethodInfoProperty, EnumInfoProperty
 
@@ -103,9 +104,12 @@ class ClassPropertySpec(Spec):
         if zplog:
             self.LOG = zplog
         self.class_spec = class_spec
-        self.name = name
-        self.default = default
-        self.type_ = type_
+
+        self._property = Property(name, type_, default)
+        self.name = self._property.name
+        self.type_ = self._property.type_
+        self.default = self._property.default
+
         self.label = label or self.name
         self.short_label = short_label or self.label
         self.index_type = index_type

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ZPropertySpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ZPropertySpec.py
@@ -7,6 +7,7 @@
 #
 ##############################################################################
 from Products.ZenRelations.zPropertyCategory import setzPropertyCategory
+from ..base.types import Property
 from .Spec import Spec
 
 
@@ -45,21 +46,15 @@ class ZPropertySpec(Spec):
             self.LOG = zplog
 
         self.zenpack_spec = zenpack_spec
-        self.name = name
-        self.type_ = type_
+
+        self._property = Property(name, type_, default)
+        self.name = self._property.name
+        self.type_ = self._property.type_
+        self.default = self._property.default
+
         self.category = category
         self.label = label or name
         self.description = description
-
-        if default is None:
-            self.default = {
-                'string': '',
-                'password': '',
-                'lines': [],
-                'boolean': False,
-            }.get(self.type_, None)
-        else:
-            self.default = default
 
     def create(self):
         """Implement specification."""

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_zprop_types.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_zprop_types.py
@@ -14,24 +14,9 @@
 from ZenPacks.zenoss.ZenPackLib.tests.ZPLTestBase import ZPLTestBase
 
 
-def get_zproperty_type(z_type):
-    """
-        For zproperties, the actual data type of a default value
-        depends on the defined type of the zProperty.
-    """
-    map = {'boolean': 'bool',
-           'int': 'int',
-           'float': 'float',
-           'string': 'str',
-           'password': 'str',
-           'lines': 'list(str)'
-    }
-    return map.get(z_type, 'str')
-
 YAML_DOC = """
 name: ZenPacks.zenoss.ZenPackLib
 zProperties:
-
   zStringProperty:
     type: string
     default: ''
@@ -49,33 +34,69 @@ zProperties:
   zLinesProperty:
     type: lines
     default: ['this','that']
+  zLongProperty:
+    type: long
+    default: 0
+classes:
+  BasicDevice:
+    base: [zenpacklib.Device]
+    properties:
+      dateTimeProperty:
+        type: date
+        default: 1975/08/21 00:00:00 UTC
+      stringProperty:
+        type: string
+        default: ''
+      passwordProperty:
+        type: password
+      booleanProperty:
+        default: false
+        type: boolean
+      intProperty:
+        default: 1
+        type: int
+      floatProperty:
+        default: 1.0
+        type: float
+      longProperty:
+        default: 0
+        type: long
+      linesProperty:
+        type: lines
+        default: ['this','that']
 """
 
 
 class TestZenProperties(ZPLTestBase):
     """
-    Ensure that zproperty types are respected
+    Ensure that property/zproperty types are respected
     """
 
     yaml_doc = YAML_DOC
 
     def test_zProperties(self):
-        zprops = self.z.cfg.zProperties
-        self.is_valid(zprops.get('zStringProperty'), str, '')
-        self.is_valid(zprops.get('zPasswordProperty'), str, '')
-        self.is_valid(zprops.get('zBooleanProperty'), bool, False)
-        self.is_valid(zprops.get('zIntProperty'), int, 1)
-        self.is_valid(zprops.get('zFloatProperty'), float, 1.0)
-        self.is_valid(zprops.get('zLinesProperty'), list, ['this', 'that'])
+        for spec in self.z.cfg.zProperties.values():
+            prop = spec._property
+            prop_cls = prop.property_class
+            prop_val = prop.default
+            self.is_valid(prop, prop_cls, prop_val)
+
+    def test_properties(self):
+        spec = self.z.cfg.classes.get('BasicDevice')
+        for p_spec in spec.properties.values():
+            prop = p_spec._property
+            prop_cls = prop.property_class
+            prop_val = prop.default
+            self.is_valid(prop, prop_cls, prop_val)
 
     def is_valid(self, spec, target_type, target_value):
         ''''''
         self.assertTrue(isinstance(spec.default, target_type),
-                'zProperty ({}) should be {}, got {}'.format(spec.name,
-                                                                      target_type.__name__,
-                                                                      type(spec.default).__name__))
+                'Property ({}) should be {}, got {}'.format(spec.name,
+                                                            target_type.__name__,
+                                                            type(spec.default).__name__))
         self.assertEquals(spec.default, target_value,
-                'zProperty ({}) should be {}, got {}'.format(spec.name,
+                'Property ({}) should be {}, got {}'.format(spec.name,
                                                             target_value,
                                                             spec.default))
 


### PR DESCRIPTION
- Standardize and validate handling of _properties entries by using
custom Property class
- Will be used to add support for documented types that don't actually work at present (such as date, selection)