### PR TITLE
Fix missing Dynamic View on some components

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ZenPackSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ZenPackSpec.py
@@ -517,7 +517,7 @@ class ZenPackSpec(Spec):
         if service_view_metatypes:
             return (
                 "Zenoss.nav.appendTo('Component', [{{\n"
-                "    id: 'subcomponent_view',\n"
+                "    id: '{zenpack_id_prefix}_subcomponent_view',\n"
                 "    text: _t('Dynamic View'),\n"
                 "    xtype: 'dynamicview',\n"
                 "    relationshipFilter: 'impacted_by',\n"
@@ -530,6 +530,7 @@ class ZenPackSpec(Spec):
                 "    }}\n"
                 "}}]);\n"
                 ).format(
+                    zenpack_id_prefix=self.id_prefix,
                     cases='\n            '.join(
                         "case '{}': return true;".format(x)
                         for x in service_view_metatypes))

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_dynamicview_nav_js.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_dynamicview_nav_js.py
@@ -78,7 +78,7 @@ class_relationships:
 """
 
 
-EXPECTED_SUBCOMPONENT_VIEW = "Zenoss.nav.appendTo('Component', [{\n    id: 'subcomponent_view',\n    text: _t('Dynamic View'),\n    xtype: 'dynamicview',\n    relationshipFilter: 'impacted_by',\n    viewName: 'service_view',\n    filterNav: function(navpanel) {\n        switch (navpanel.refOwner.componentType) {\n            case 'Application': return true;\n            case 'Linux': return true;\n            default: return false;\n        }\n    }\n}]);"
+EXPECTED_SUBCOMPONENT_VIEW = "Zenoss.nav.appendTo('Component', [{\n    id: 'ZenPacks_zenpacklib_TestLinuxStorage_subcomponent_view',\n    text: _t('Dynamic View'),\n    xtype: 'dynamicview',\n    relationshipFilter: 'impacted_by',\n    viewName: 'service_view',\n    filterNav: function(navpanel) {\n        switch (navpanel.refOwner.componentType) {\n            case 'Application': return true;\n            case 'Linux': return true;\n            default: return false;\n        }\n    }\n}]);"
 
 
 class TestDynamicViewComponentNav(ZPLTestBase):

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -29,6 +29,8 @@ Release 2.0.4
 
 Fixes
 
+* Fix for missing Dynamic View on some components (ZPS-703)
+
 
 Release 2.0.3
 -------------

--- a/tests/test_specs.py
+++ b/tests/test_specs.py
@@ -91,7 +91,7 @@ class_relationships:
 
 EXPECTED_SUBCOMPONENT_VIEW = """
 Zenoss.nav.appendTo('Component', [{
-    id: 'subcomponent_view',
+    id: 'ZenPacks_zenpacklib_TestLinuxStorage_subcomponent_view',
     text: _t('Dynamic View'),
     xtype: 'dynamicview',
     relationshipFilter: 'impacted_by',


### PR DESCRIPTION
Some ZenPacks such as Docker have custom component types, but no custom
device type. They do this by patching their component's relationship
onto ZenModel.Device. The problem that can then occur is multiple
component Dynamic View (subcomponent_view) Component navigations can get
created for a single device type. The two views will disagree about
which types of components should have a Dynamic View. The user will
always end up seeing this as components not having a DynamicView in
their Display drop-down when they should.

This fix namespaces the subcomponent_view, so it's OK to have multiple
registered for the same device.

Refs ZPS-703.

The actual fix for ZPS-703 is in the Docker ZenPack. This commit is to
incorporate the fix into ZenPackLib proper.