### PR TITLE
Fix for not creating device classes in some cases

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/loaders.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/loaders.py
@@ -84,7 +84,7 @@ class ZenPackSpecLoader(OrderedLoader):
     def construct_specsparameters(self, node, spectype):
         """constructor for SpecsParameters"""
         from ..spec.Spec import Spec
-        spec_class = {x.__name__: x for x in Spec.__subclasses__()}.get(spectype, None)
+        spec_class = {x.__name__: x for x in Spec.get_subclasses()}.get(spectype, None)
 
         if not spec_class:
             self.yaml_error(yaml.constructor.ConstructorError(

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/DeviceClassSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/DeviceClassSpec.py
@@ -6,11 +6,11 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
-from .Spec import Spec
+from .OrganizerSpec import OrganizerSpec
 from .RRDTemplateSpec import RRDTemplateSpec
 
 
-class DeviceClassSpec(Spec):
+class DeviceClassSpec(OrganizerSpec):
     """Initialize a DeviceClass via Python at install time."""
 
     def __init__(
@@ -41,11 +41,14 @@ class DeviceClassSpec(Spec):
             :param protocol: Protocol to use for registered devtype
             :type protocol: str
         """
-        super(DeviceClassSpec, self).__init__(_source_location=_source_location)
+        super(DeviceClassSpec, self).__init__(
+            zenpack_spec,
+            path,
+            _source_location=_source_location)
+
         if zplog:
             self.LOG = zplog
-        self.zenpack_spec = zenpack_spec
-        self.path = path.lstrip('/')
+
         self.create = bool(create)
         self.remove = bool(remove)
         self.description = description
@@ -58,3 +61,7 @@ class DeviceClassSpec(Spec):
 
         self.templates = self.specs_from_param(
             RRDTemplateSpec, 'templates', templates, zplog=self.LOG)
+
+    def get_root(self, dmd):
+        """Return the root object for this organizer."""
+        return dmd.Devices

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/OrganizerSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/OrganizerSpec.py
@@ -1,0 +1,52 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from .Spec import Spec
+
+
+class OrganizerSpec(Spec):
+    """Abstract base for organizer specifications.
+
+    Subclasses:
+
+    * DeviceClassSpec
+    * EventClassSpec
+    * ProcessClassOrganizerSpec
+
+    """
+
+    def __init__(self, zenpack_spec, path, _source_location=None, zplog=None):
+        """Create an Organizer specification."""
+        super(OrganizerSpec, self).__init__(_source_location=_source_location)
+
+        if zplog:
+            self.LOG = zplog
+
+        self.zenpack_spec = zenpack_spec
+        self.path = path.lstrip("/")
+
+    def get_root(self, dmd):
+        """Return the root for this organizer.
+
+        Must be overridden by subclasses. DeviceClassSpec, for example, would
+        return dmd.Devices.
+
+        """
+        raise NotImplementedError
+
+    def get_organizer(self, dmd):
+        """Return organizer object for this specification or None."""
+        try:
+            organizer = self.get_root(dmd).getOrganizer(self.path)
+        except KeyError:
+            return
+        else:
+            # Guard against acquisition returning us the wrong organizer.
+            if organizer.getOrganizerName().lstrip("/") == self.path:
+                return organizer

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDTemplateSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDTemplateSpec.py
@@ -161,10 +161,10 @@ class RRDTemplateSpec(Spec):
             return template
 
     def remove(self, dmd, id=None):
-        try:
-            device_class = dmd.Devices.getOrganizer(self.deviceclass_spec.path)
-        except KeyError:
+        device_class = self.deviceclass_spec.get_organizer(dmd)
+        if not device_class:
             return
+
         # override object id if provided
         t_id = id or self.name
         existing_template = device_class.rrdTemplates._getOb(t_id, None)

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/Spec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/Spec.py
@@ -418,3 +418,11 @@ class Spec(object):
             return InterfaceClass
         else:
             return type
+
+    @classmethod
+    def get_subclasses(cls):
+        """Generate recursive subclasses of this class."""
+        for subclass in cls.__subclasses__():
+            yield subclass
+            for subsubclass in subclass.get_subclasses():
+                yield subsubclass

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_device_class_removal.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_device_class_removal.py
@@ -37,7 +37,7 @@ class TestDeviceClassRemoval(ZPLTestBase):
 
     def test_device_class(self):
         # instantiate the ZenPack class
-        zenpack = ZenPack(self.dmd)
+        zenpack = ZenPack(self.app)
 
         # create the device class
         for dcname, dcspec in self.z.cfg.device_classes.items():

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,7 @@ Release 2.0.4
 Fixes
 
 * Fix for missing Dynamic View on some components (ZPS-703)
+* Fix for failure to create device classes in uncommon case (ZPS-1012)
 
 
 Release 2.0.3


### PR DESCRIPTION
The current develop branch of the Windows ZenPack is experiencing a
problem with ZenPack where the /Server/Microsoft/Windows device class
doesn't get installed when the ZenPack is installed.

This issue seems to have been brought to light by the fix for ZEN-925 in
ZenPackLib 2.0.3. Specifically 07cf5e5.

Acquisition strikes again. When the following device classes exist..

- /Server/Windows
- /Server/Microsoft

The following code will return the /Server/Windows device class.

    dmd.Devices.getOrganizer("Server/Microsoft/Windows")

Obviously this isn't what we want, and it results in ZenPackLib thinking
that it doesn't need to create the /Server/Microsoft/Windows device
class because it already exists.

This fix should address that problem by adding an additional check to
after the call to getOrganizer() that makes sure the returned device
class has the same path as what was asked for.

There's a bit of reorganization in this change to put all of the
organizer specs under a new abstract base class called OrganizerSpec so
that the ability to safely get an organizer can be shared.

Fixes ZPS-1012.