### PR TITLE
Fix event mappings with id/eventClassKey mismatch

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/EventClassMappingSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/EventClassMappingSpec.py
@@ -73,4 +73,5 @@ class EventClassMappingSpec(Spec):
             if getattr(mapping, x) != getattr(self, x):
                 setattr(mapping, x, getattr(self, x, None))
 
-        self.zpl_managed = True
+        mapping.zpl_managed = True
+        mapping.index_object()

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -31,6 +31,7 @@ Fixes
 
 * Fix for missing Dynamic View on some components (ZPS-703)
 * Fix for failure to create device classes in uncommon case (ZPS-1012)
+* Fix event class mappings with mismatched id and eventClassKey (ZPS-1016)
 
 
 Release 2.0.3


### PR DESCRIPTION
Event class mappings with an eventClassKey different than their id were
getting indexed while their id and eventClassKey were still identical
prior to zenpacklib setting the custom eventClassKey. This resulted in
the correct eventClassKey not being indexed in
dmd.Events.eventClassSearch, and therefore the mappings not matching any
events.

This simple fix indexes mappings after all of their properties have been
set to solve the problem.

Fixes ZPS-1016. Fixes part of ZPS-900.