### PR TITLE
Fix template change detection during install

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/params/DeviceClassSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/DeviceClassSpecParams.py
@@ -6,15 +6,15 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
-from .SpecParams import SpecParams
+
+from .OrganizerSpecParams import OrganizerSpecParams
 from .RRDTemplateSpecParams import RRDTemplateSpecParams
 from ..spec.DeviceClassSpec import DeviceClassSpec
 
 
-class DeviceClassSpecParams(SpecParams, DeviceClassSpec):
+class DeviceClassSpecParams(OrganizerSpecParams, DeviceClassSpec):
     def __init__(self, zenpack_spec, path, zProperties=None, templates=None, **kwargs):
-        SpecParams.__init__(self, **kwargs)
-        self.path = path
+        OrganizerSpecParams.__init__(self, zenpack_spec, path, **kwargs)
         self.zProperties = zProperties
         self.templates = self.specs_from_param(
             RRDTemplateSpecParams, 'templates', templates, zplog=self.LOG)

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/EventClassSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/EventClassSpecParams.py
@@ -7,15 +7,14 @@
 #
 ##############################################################################
 
-from .SpecParams import SpecParams
+from .OrganizerSpecParams import OrganizerSpecParams
 from .EventClassMappingSpecParams import EventClassMappingSpecParams
 from ..spec.EventClassSpec import EventClassSpec
 
 
-class EventClassSpecParams(SpecParams, EventClassSpec):
+class EventClassSpecParams(OrganizerSpecParams, EventClassSpec):
     def __init__(self, zenpack_spec, path, description='', transform='', mappings=None, **kwargs):
-        SpecParams.__init__(self, **kwargs)
-        self.path = path
+        OrganizerSpecParams.__init__(self, zenpack_spec, path, **kwargs)
         self.description = description
         self.transform = transform
         self.mappings = self.specs_from_param(

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/OrganizerSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/OrganizerSpecParams.py
@@ -1,0 +1,17 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+from .SpecParams import SpecParams
+from ..spec.OrganizerSpec import OrganizerSpec
+
+
+class OrganizerSpecParams(SpecParams, OrganizerSpec):
+    def __init__(self, zenpack_spec, path, **kwargs):
+        SpecParams.__init__(self, **kwargs)
+        self.zenpack_spec = zenpack_spec
+        self.path = path.lstrip("/")

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/ProcessClassOrganizerSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/ProcessClassOrganizerSpecParams.py
@@ -7,15 +7,14 @@
 #
 ##############################################################################
 
-from .SpecParams import SpecParams
+from .OrganizerSpecParams import OrganizerSpecParams
 from .ProcessClassSpecParams import ProcessClassSpecParams
 from ..spec.ProcessClassOrganizerSpec import ProcessClassOrganizerSpec
 
 
-class ProcessClassOrganizerSpecParams(SpecParams, ProcessClassOrganizerSpec):
+class ProcessClassOrganizerSpecParams(OrganizerSpecParams, ProcessClassOrganizerSpec):
     def __init__(self, zenpack_spec, path, description='', process_classes=None, remove=False, **kwargs):
-        SpecParams.__init__(self, **kwargs)
-        self.path = path
+        OrganizerSpecParams.__init__(self, zenpack_spec, path, **kwargs)
         self.description = description
         self.remove = remove
         self.process_classes = self.specs_from_param(

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,8 @@ Release 2.0.5
 Fixes
 
 
+* Fix failure to backup customized tempaltes during upgrade (ZPS-1176)
+
 Release 2.0.4
 -------------
 


### PR DESCRIPTION
Recent addition of OrganizerSpec leaves the "path" attribute with
leading "/" characters remaining during the ZenPack install.  This
causes the get_organizer method to fail when called against these
SpecParam-generated objects.  This in turn causes the template change
detection and backup routines to fail, losing customizations in the
process.  

Added OrganizerSpecParams class with path attribute modifiers,
and rebased relevant SpecParams classes on this instead of SpecParams.