### PR TITLE
Make template backup names a bit more friendly

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
@@ -90,7 +90,8 @@ class ZenPack(ZenPackBase):
                     # preserve the backup if different
                     if diff:
                         create_template = True
-                        backup_name = "{}-preupgrade-{}".format(mtname, int(time.time()))
+                        time_str = time.strftime("%Y%m%d%H%M", time.localtime())
+                        backup_name = "{}-preupgrade-{}".format(mtname, time_str)
                         deviceclass.rrdTemplates.manage_renameObject(template.id, backup_name)
                         LOG.info(
                             "Existing monitoring template {}/{} differs from "

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -29,6 +29,7 @@ Release 2.0.5
 
 Fixes
 
+* Template backups use YYYYMMDDHHMM format instead of unix timestamp.
 
 Release 2.0.4
 -------------


### PR DESCRIPTION
- Changed the "preupgrade" template naming to use YYYYMMDDHHMM instead
of the default unix timestamp style since it will make more sense to
users.