### PR TITLE
Ensure that template changes are detected during pre-2.0 upgrades

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/tests/test_device_class_removal.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_device_class_removal.py
@@ -41,14 +41,14 @@ class TestDeviceClassRemoval(ZPLTestBase):
 
         # create the device class
         for dcname, dcspec in self.z.cfg.device_classes.items():
-            zenpack.create_device_class(self, dcspec)
+            zenpack.create_device_class(self.app, dcspec)
             # verify that it was created
             self.assertTrue(self.device_class_exists(dcspec.path),
                             'Device class {} was not created'.format(dcspec.path))
 
         for dcname, dcspec in self.z.cfg.device_classes.iteritems():
             if dcspec.remove:
-                zenpack.remove_device_class(self, dcspec)
+                zenpack.remove_device_class(self.app, dcspec)
                 # verify that it was removed
                 self.assertFalse(self.device_class_exists(dcspec.path),
                                 'Device class {} was not removed'.format(dcspec.path))

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,8 +30,8 @@ Release 2.0.5
 Fixes
 
 * Template backups use YYYYMMDDHHMM format instead of unix timestamp.
-
-* Fix failure to backup customized tempaltes during upgrade (ZPS-1176)
+* Fix failure to back up customized templates during upgrade from pre-2.0 ZenPacks (ZPS-1195)
+* Fix failure to back up customized templates during upgrade (ZPS-1176)
 
 Release 2.0.4
 -------------


### PR DESCRIPTION
- Fixes ZPS-787
- Updated ZenPack install and remove methods to account for both ZPL
2.0-based and legacy zenpack-provided templates
- Change detection now works across versions
- New methods added to make the associated logic more contained and
consistent (and hopefully more easily understood)
- Methods should be abstract enough to later apply to other ZPL-provided
objects like event classes, process sets, etc.
- Changed various 'dmd' references to app.zport.dmd for readability