### PR TITLE
Fix group permissions for zenoss user

### DIFF
--- a/docs/development-environment.rst
+++ b/docs/development-environment.rst
@@ -91,6 +91,13 @@ groups respectively.
     usermod -a -G wheel zenoss
     usermod -a -G docker zenoss
 
+If running Zenoss 5.2 or later, we need to add the user to the *serviced* group
+as well, in order to interact with serviced containers.
+
+.. code-block:: bash
+
+    usermod -a -G wheel serviced
+
 .. _helper-aliases-and-functions:
 
 Helper Aliases and Functions


### PR DESCRIPTION
Apparently, in Zenoss 5.2, serviced is assigned to the `serviced` group, where before it was assigned to the root group.  The `zenoss` user we create in this tutorial needs to be added to that group in order do things like attach to the zope container.