### PR TITLE
Fix bad copy pasta

### DIFF
--- a/docs/development-environment.rst
+++ b/docs/development-environment.rst
@@ -96,7 +96,7 @@ as well, in order to interact with serviced containers.
 
 .. code-block:: bash
 
-    usermod -a -G wheel serviced
+    usermod -a -G serviced zenoss
 
 .. _helper-aliases-and-functions:
 


### PR DESCRIPTION
I copied and pasted the new permissions like, and then edited the wrong word before.  Fixed now.