### PR TITLE
Fix missing paths from getPaths() issue (ZPS-1262)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/base/ComponentBase.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/base/ComponentBase.py
@@ -231,6 +231,13 @@ class ComponentBase(ModelBase):
         """Return name of containing relationship."""
         for relname, relschema in self._relations:
             if issubclass(relschema.remoteType, ToManyCont):
+                # skip if it's not the real containing rel
+                # for instance an inherited os.filesystems for sub-classed FileSystem
+                rel = getattr(self, relname, None)
+                if rel:
+                    if not rel.obj:
+                        continue
+
                 return relname
         raise ZenSchemaError("%s (%s) has no containing relationship" % (self.__class__.__name__, self))
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/wrapper/ComponentPathReporter.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/wrapper/ComponentPathReporter.py
@@ -9,23 +9,59 @@
 from zope.component import adapts
 from zope.interface import implements
 from Products.Zuul.catalog.interfaces import IPathReporter
-from Products.Zuul.catalog.paths import DefaultPathReporter, relPath
+from Products.Zuul.catalog.paths import (
+     DefaultPathReporter,
+     DevicePathReporter,
+     ServicePathReporter as ServicePathReporterBase,
+     InterfacePathReporter as InterfacePathReporterBase,
+     ProcessPathReporter as ProcessPathReporterBase,
+     ProductPathReporter as ProductPathReporterBase,
+     relPath
+     )
+
 from ..base.ComponentBase import ComponentBase
+from ..base.Component import (
+     HWComponent,
+     IpInterface,
+     OSProcess,
+     Service,
+)
 
 
-class ComponentPathReporter(DefaultPathReporter):
-
-    """Global catalog path reporter adapter factory for components."""
-
+class ComponentPathMixIn(DefaultPathReporter):
+    """Global catalog path reporter override"""
     implements(IPathReporter)
-    adapts(ComponentBase)
 
     def getPaths(self):
-        paths = super(ComponentPathReporter, self).getPaths()
+        paths = super(ComponentPathMixIn, self).getPaths()
 
         for facet in self.context.get_facets():
             rp = relPath(facet, facet.containing_relname)
             paths.extend(rp)
 
         return paths
+
+
+class ComponentPathReporter(ComponentPathMixIn):
+    """Global catalog path reporter adapter factory for basic components."""
+    adapts(ComponentBase)
+
+
+class ProductPathReporter(ComponentPathMixIn, ProductPathReporterBase):
+    """"""
+    adapts(HWComponent)
+
+
+class InterfacePathReporter(ComponentPathMixIn, InterfacePathReporterBase):
+    """"""
+    adapts(IpInterface)
+
+
+class ProcessPathReporter(ComponentPathMixIn, ProcessPathReporterBase):
+    """"""
+    adapts(OSProcess)
+
+class ServicePathReporter(ComponentPathMixIn, ServicePathReporterBase):
+    """"""
+    adapts(Service)
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/zuul.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/zuul.py
@@ -59,12 +59,13 @@ from Products.Zuul.facades.devicefacade import DeviceFacade
 from Products.Zuul.facades.processfacade import ProcessFacade
 from Products.Zuul.facades.servicefacade import ServiceFacade
 
-from Products.Zuul.catalog.paths import (
-     DevicePathReporter,
+from Products.Zuul.catalog.paths import DevicePathReporter
+
+from .wrapper.ComponentPathReporter import (
      ServicePathReporter,
      InterfacePathReporter,
      ProcessPathReporter,
-     ProductPathReporter
+     ProductPathReporter,
      )
 
 schema_map = {

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_proxy_path_reporters.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_proxy_path_reporters.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+"""
+    Ensure that path reporters work correctly for ZPL proxy classes
+"""
+
+from ZenPacks.zenoss.ZenPackLib.tests.ZPLTestBase import ZPLTestBase
+
+
+YAML_DOC = '''
+name: ZenPacks.zenoss.ZenPackLib
+classes:
+  MyDev:
+    base: [zenpacklib.Device]
+  BaseClass1:
+    base: [zenpacklib.Component]
+  BaseClass2:
+    base: [zenpacklib.Component]
+  SubClass1:
+    base: [BaseClass1]
+  SubClass2:
+    base: [BaseClass1]
+  SubClass3:
+    base: [BaseClass2]
+  SubClass4:
+    base: [zenpacklib.HWComponent]
+    
+class_relationships:
+  - MyDev 1:MC SubClass1
+  - MyDev 1:MC SubClass2
+  - MyDev 1:MC SubClass3
+  - MyDev 1:MC SubClass4
+  - SubClass1 M:M SubClass2 # works
+  - SubClass2 M:M SubClass3 # works
+  - SubClass2 M:M SubClass4 # broken
+'''
+
+
+class TestPathReporters(ZPLTestBase):
+    """
+    Ensure that path reporters work correctly for ZPL proxy classes
+    """
+
+    yaml_doc = YAML_DOC
+
+    def test_path_reporters(self):
+        ''''''
+        target_path = ('mydev-0', 'subClass2s', 'subclass2-0')
+
+        # registering ourself but ZPL would normally do this implicitly for basic classes
+        from ZenPacks.zenoss.ZenPackLib.lib.gsm import GSM
+        from Products.Zuul.catalog.interfaces import IPathReporter
+        from ZenPacks.zenoss.ZenPackLib.lib.wrapper.ComponentPathReporter import ComponentPathReporter
+        spec = self.z.cfg.classes.get('SubClass3')
+        GSM.registerAdapter(ComponentPathReporter, (spec.model_class,), IPathReporter)
+
+        for ob in self.z.obs:
+            if ob.__class__.__name__ not in ['SubClass3', 'SubClass4']:
+                continue
+            rpt = IPathReporter(ob)
+            self.assertTrue(target_path in rpt.getPaths(),
+                            'Path reporter testing failed for {} ({})'.format(ob.__class__.__name__, rpt.getPaths()))
+
+
+def test_suite():
+    """Return test suite for this module."""
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestPathReporters))
+    return suite
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()


### PR DESCRIPTION
- Fixes ZPS-1262

Two main issues are involved here.  First, the various PathReporters
used by ZPL proxy classes need to have their own getPaths() overrides
like the one ZPL provides.

Second, the ComponentBase containing_relname method fails for proxy
classes whose primary parents are OperatingSystem or Hardware, since
these are only valid if the subclass has the same name as the parent
class (like FileSystem).  Otherwise, the device is directly related to
the class.