### PR TITLE
Ensure that Severity of 0 (Clear) is respected (ZPS-1454)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/base/types.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/base/types.py
@@ -112,7 +112,7 @@ class Severity(int):
                'clear': 0}
 
     def __new__(cls, value):
-        if not value:
+        if not value and not isinstance(value, int):
             return value
         return int.__new__(cls, cls.validate(value))
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/Dumper.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/Dumper.py
@@ -200,13 +200,13 @@ class Dumper(yaml.Dumper):
     def represent_severity(self, data):
         """represent Severity"""
         orig = getattr(data, 'orig')
-        if orig:
+        if orig is None:
+            raise ValueError("'{}' is not a valid value for severity.".format(orig))
+        else:
             if isinstance(orig, str):
                 return self.represent_str(orig)
             elif isinstance(orig, int):
                 return self.represent_int(orig)
-        if orig is None:
-            raise ValueError("'{}' is not a valid value for severity.".format(orig))
 
     def relschemaspec_to_str(self, spec):
         # Omit relation names that are their defaults.

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_severity_validation.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_severity_validation.py
@@ -48,6 +48,14 @@ device_classes:
           E:
             type: MinMaxThreshold
             dsnames: [A_A]
+          F:
+            type: MinMaxThreshold
+            dsnames: [A_A]
+            severity: 0
+          G:
+            type: MinMaxThreshold
+            dsnames: [A_A]
+            severity: Clear
 """
 
 
@@ -71,6 +79,12 @@ device_classes:
             severity: NotSure
           E:
             dsnames: [A_A]
+          F:
+            dsnames: [A_A]
+            severity: 0
+          G:
+            dsnames: [A_A]
+            severity: Clear
         datasources:
           A:
             type: SNMP

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -29,6 +29,9 @@ Release 2.0.6
 
 Fixes
 
+* Fix mishandling of 0/clear severity (ZPS-1454)
+* Fix attempts to load non-YAML files (ZPS-1483)
+
 Release 2.0.5
 -------------
 


### PR DESCRIPTION
- Fixes ZPS-1454
- Update existence testing of values to include zero values
- Updated unit test to account for this scenario