### PR TITLE
Add EventClass and ProcessClassOrganizer components to zenpack's pack…

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/EventClassSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/EventClassSpec.py
@@ -47,11 +47,16 @@ class EventClassSpec(OrganizerSpec):
         self.mappings = self.specs_from_param(
             EventClassMappingSpec, 'mappings', mappings, zplog=self.LOG)
 
-    def instantiate(self, dmd):
+    def instantiate(self, dmd, addToZenPack=True):
         ecObject = self.get_organizer(dmd)
         if not ecObject:
             ecObject = dmd.Events.createOrganizer(self.path)
             ecObject.zpl_managed = True
+
+        # Set to false to facilitate testing without ZP installation.
+        if addToZenPack:
+            # Add this EventClass to the zenpack.
+            ecObject.addToZenPack(pack=self.zenpack_spec.name)
 
         if self.description != '':
             if not ecObject.description == self.description:

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ProcessClassOrganizerSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ProcessClassOrganizerSpec.py
@@ -43,11 +43,16 @@ class ProcessClassOrganizerSpec(OrganizerSpec):
         self.process_classes = self.specs_from_param(
             ProcessClassSpec, 'process_classes', process_classes, zplog=self.LOG)
 
-    def create(self, dmd):
+    def create(self, dmd, addToZenPack=True):
         porg = self.get_organizer(dmd)
         if not porg:
             porg = dmd.Processes.createOrganizer(self.path)
             porg.zpl_managed = True
+
+        # Set to false to facilitate testing without ZP installation.
+        if addToZenPack:
+             # Add this OSProcessOrganizer to the zenpack.
+            porg.addToZenPack(pack=self.zenpack_spec.name)
 
         if porg.description != self.description:
             porg.description = self.description


### PR DESCRIPTION
…ables.

Fixes ZPS-1601

Therefore, the dump-event-classes and dump-process-classes can dump ZPL components and add them to appropriate ZenPack.