### PR TITLE
Fix slow component grid loading

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassSpec.py
@@ -1121,13 +1121,7 @@ class ClassSpec(Spec):
 
     def get_datapoints_to_fetch(self):
         """return list of datapoint names for templates associated with this class"""
-        dsnames = []
-        for dc_spec in self.zenpack.device_classes.values():
-            for t_name, t_spec in dc_spec.templates.items():
-                if t_name in self.monitoring_templates:
-                    dsnames += t_spec.datapoints_to_fetch
-        dsnames = list(set(dsnames))
-        return dsnames
+        return [spec.datapoint for spec in self.properties.values() if spec.datapoint and spec.grid_display]
 
     @property
     def containing_js_fields(self):

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDTemplateSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDTemplateSpec.py
@@ -63,8 +63,6 @@ class RRDTemplateSpec(Spec):
 
         self.validate_references()
 
-        self.datapoints_to_fetch = self.get_dp_names()
-
     def validate_references(self):
         """
             validate 
@@ -85,13 +83,6 @@ class RRDTemplateSpec(Spec):
                                        'Graph Point',
                                        set([gp_spec.dpName]),
                                        ds_dp_names)
-
-    def get_dp_names(self):
-        """return list of datapoint names"""
-        dp_names = []
-        for ds_spec in self.datasources.values():
-            dp_names += [ id for id in ds_spec.datapoints.keys() ]
-        return list(set(dp_names))
 
     def get_ds_dp_names(self):
         """return set of dsname_dpname"""


### PR DESCRIPTION
Revise 'dataPointsToFetch' to include only metrics designated for use in
component grid columns.  Previous behavior loaded all metrics for all
components on a given device, which resulted in the slow loading
behavior observed