### PR TITLE
add "reset" option to DeviceClassSpec (ZPS-810)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/DeviceClassSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/DeviceClassSpec.py
@@ -23,6 +23,7 @@ class DeviceClassSpec(OrganizerSpec):
             templates=None,
             description=None,
             protocol=None,
+            reset=False,
             _source_location=None,
             zplog=None):
         """
@@ -40,6 +41,8 @@ class DeviceClassSpec(OrganizerSpec):
             :type description: str
             :param protocol: Protocol to use for registered devtype
             :type protocol: str
+            :param reset:  If True, reset any zProperties that differ from given
+            :type reset: bool
         """
         super(DeviceClassSpec, self).__init__(
             zenpack_spec,
@@ -53,6 +56,7 @@ class DeviceClassSpec(OrganizerSpec):
         self.remove = bool(remove)
         self.description = description
         self.protocol = protocol
+        self.reset = reset
 
         if zProperties is None:
             self.zProperties = {}

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_device_class_existing_zproperties.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_device_class_existing_zproperties.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+"""
+    Test that device classes can optionally have their zProperties reset (ZPS-810)
+"""
+
+from ZenPacks.zenoss.ZenPackLib.tests.ZPLTestBase import ZPLTestBase
+from ZenPacks.zenoss.ZenPackLib.lib.base.ZenPack import ZenPack
+
+
+YAML_DOC = """
+name: ZenPacks.zenoss.ZenPackLib
+
+device_classes:
+  /Server:
+    zProperties:
+      zSnmpMonitorIgnore: False
+    reset: true
+"""
+
+
+class TestZPropertyReset(ZPLTestBase):
+    """
+    Test that device classes can be removed (ZEN-18134)
+    """
+
+    yaml_doc = YAML_DOC
+
+    def test_device_class(self):
+        # instantiate the ZenPack class
+        zenpack = ZenPack(self.app)
+
+        # create the device class
+        for dcname, dcspec in self.z.cfg.device_classes.items():
+            zenpack.create_device_class(self.app, dcspec)
+            # verify that it was created
+            dc = self.device_class_exists(dcspec.path)
+            self.assertTrue(dc,
+                            'Device class {} does not exist'.format(dcspec.path))
+
+        for dcname, dcspec in self.z.cfg.device_classes.iteritems():
+            if dcspec.reset:
+                zenpack.set_zproperties(self.app, dc, dcspec)
+            print 'zSnmpMonitorIgnore', getattr(dc, 'zSnmpMonitorIgnore')
+            self.assertFalse(getattr(dc, 'zSnmpMonitorIgnore'),
+                            'Device class {} zProperty was not set correctly'.format(dcspec.path))
+
+
+    def device_class_exists(self, path):
+        try:
+            ob = self.dmd.Devices.getOrganizer(path)
+            return ob
+        except KeyError:
+            return
+
+def test_suite():
+    """Return test suite for this module."""
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestZPropertyReset))
+    return suite
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()

--- a/docs/yaml-device-classes.rst
+++ b/docs/yaml-device-classes.rst
@@ -170,3 +170,18 @@ protocol
   :Required: No
   :Type: string
   :Default Value: None
+
+reset
+  :Description: If true, any zProperties defined here will override those of the target device class, if it exists
+  :Required: No
+  :Type: boolean
+  :Default Value: false
+
+.. note::
+
+  The *reset* option is not the preferred way to handle migration or changes to zProperty values between ZenPack versions.  It is likely to cause heartache
+  in cases where the target Device Class is not supplied exclusively by the ZenPack, for instance, since there is no way to control which version of the
+  desired zProperty values would be authoritative or what the expected value should be if a single device class is targeted by multiple ZenPacks.  Several other
+  bad scenarios exist, so use this option with extreme caution and preferably use migration scripts to handle these types of changes.
+
+  


### PR DESCRIPTION
- Added optional "reset" parameter to facilitate override of zProperties
on preexisting device class
- Added test_device_class_existing_zproperties unit test