### PR TITLE
Better support for YAML multi-line text (ZPS-444)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/base/types.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/base/types.py
@@ -143,3 +143,5 @@ class Severity(int):
         self.orig = value
         self.text = self.to_text.get(self)
 
+class multiline(str):
+    """Subclass representing multi-line text"""

--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/Dumper.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/Dumper.py
@@ -208,6 +208,13 @@ class Dumper(yaml.Dumper):
             elif isinstance(orig, int):
                 return self.represent_int(orig)
 
+    def represent_multiline(self, data):
+        """Represent multi-line text"""
+        for c in u"\u000a\u000d\u001c\u001d\u001e\u0085\u2028\u2029":
+            if c in unicode(data):
+                return self.represent_scalar('tag:yaml.org,2002:str', data, style='|')
+        return self.represent_str(data)
+
     def relschemaspec_to_str(self, spec):
         # Omit relation names that are their defaults.
         left_optrelname = "" if spec.left_relname == spec.default_left_relname else "({})".format(spec.left_relname)
@@ -306,6 +313,9 @@ Dumper.add_representer(ProcessClassSpecParams, Dumper.represent_spec)
 Dumper.add_representer(ImpactTriggerSpecParams, Dumper.represent_spec)
 Dumper.add_representer(LinkProviderSpecParams, Dumper.represent_spec)
 # representers for custom types
-from ..base.types import Color, Severity
+from ..base.types import Color, Severity, multiline
 Dumper.add_representer(Color, SafeRepresenter.represent_str)
 Dumper.add_representer(Severity, Dumper.represent_severity)
+Dumper.add_representer(multiline, Dumper.represent_multiline)
+
+

--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/loaders.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/loaders.py
@@ -15,7 +15,7 @@ import keyword
 from collections import OrderedDict
 from ..functions import ZENOSS_KEYWORDS, JS_WORDS, relname_from_classname, find_keyword_cls
 from .ZenPackLibLog import ZPLOG, DEFAULTLOG
-from ..base.types import Severity
+from ..base.types import Severity, multiline
 
 
 class OrderedLoader(yaml.Loader):
@@ -262,6 +262,9 @@ class ZenPackSpecLoader(OrderedLoader):
 
                 elif expected_type == 'Severity':
                     yaml_value = self.construct_severity(value_node)
+
+                elif expected_type == 'multiline':
+                    yaml_value = self.construct_python_str(value_node)
 
                 elif re.match('^SpecsParameter\((.*)\)$', expected_type):
                     m = re.match('^SpecsParameter\((.*)\)$', expected_type)

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/EventClassMappingSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/EventClassMappingSpecParams.py
@@ -6,9 +6,8 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
-
+from ..base.types import multiline
 from Acquisition import aq_base
-
 from .SpecParams import SpecParams
 from ..spec.EventClassMappingSpec import EventClassMappingSpec
 
@@ -33,10 +32,10 @@ class EventClassMappingSpecParams(SpecParams, EventClassMappingSpec):
         self.sequence = sequence
         self.rule = rule
         self.regex = regex
-        self.example = example
-        self.explanation = explanation
-        self.resolution = resolution
-        self.transform = transform
+        self.example = multiline(example)
+        self.explanation = multiline(explanation)
+        self.resolution = multiline(resolution)
+        self.transform = multiline(transform)
         self.remove = remove
 
     @classmethod
@@ -45,10 +44,12 @@ class EventClassMappingSpecParams(SpecParams, EventClassMappingSpec):
         SpecParams.__init__(self)
         mapping = aq_base(mapping)
 
-        _properties = ['eventClassKey', 'sequence', 'rule', 'regex',
-                       'example', 'explanation', 'resolution', 'transform']
-        for x in _properties:
+        for x in ['eventClassKey', 'sequence', 'rule', 'regex']:
             setattr(self, x, getattr(mapping, x, None))
 
+        self.example = multiline(mapping.example)
+        self.explanation = multiline(mapping.explanation)
+        self.resolution = multiline(mapping.resolution)
+        self.transform = multiline(mapping.transform)
         self.remove = remove
         return self

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/EventClassSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/EventClassSpecParams.py
@@ -6,7 +6,7 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
-
+from ..base.types import multiline
 from .OrganizerSpecParams import OrganizerSpecParams
 from .EventClassMappingSpecParams import EventClassMappingSpecParams
 from ..spec.EventClassSpec import EventClassSpec
@@ -16,7 +16,7 @@ class EventClassSpecParams(OrganizerSpecParams, EventClassSpec):
     def __init__(self, zenpack_spec, path, description='', transform='', mappings=None, **kwargs):
         OrganizerSpecParams.__init__(self, zenpack_spec, path, **kwargs)
         self.description = description
-        self.transform = transform
+        self.transform = multiline(transform)
         self.mappings = self.specs_from_param(
             EventClassMappingSpecParams, 'mappings', mappings)
 
@@ -27,7 +27,7 @@ class EventClassSpecParams(OrganizerSpecParams, EventClassSpec):
 
         self.path = eventclass
         self.description = description
-        self.transform = transform
+        self.transform = multiline(transform)
         self.remove = remove
         return self
 
@@ -37,7 +37,7 @@ class EventClassSpecParams(OrganizerSpecParams, EventClassSpec):
         OrganizerSpecParams.__init__(self)
 
         self.description = eventclass.description
-        self.transform = eventclass.transform
+        self.transform = multiline(eventclass.transform)
         self.remove = remove
         self.mappings = {x.id: EventClassMappingSpecParams.fromObject(x) for x in eventclass.instances()}
         return self

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/EventClassMappingSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/EventClassMappingSpec.py
@@ -6,7 +6,7 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
-
+from ..base.types import multiline
 from .Spec import Spec
 
 
@@ -37,13 +37,13 @@ class EventClassMappingSpec(Spec):
           :param regex: a regular expression to match an event
           :type regex: str
           :param transform: a python expression for transformation
-          :type transform: str
+          :type transform: multiline
           :param example: debugging string to use in the regular expression ui testing.
-          :type example: str
+          :type example: multiline
           :param explanation: Enter a textual description for matches for this event class mapping. Use in conjunction with the Resolution field.
-          :type explanation: str
+          :type explanation: multiline
           :param resolution: Use the Resolution field to enter resolution instructions for clearing the event.
-          :type resolution: str
+          :type resolution: multiline
           :param remove: Remove the Mapping when the ZenPack is removed
           :type remove: bool
         """
@@ -53,12 +53,12 @@ class EventClassMappingSpec(Spec):
         self.name = name
         self.eventClassKey = eventClassKey or name
         self.sequence = sequence
-        self.transform = transform
+        self.transform = multiline(transform)
         self.rule = rule
         self.regex = regex
-        self.example = example
-        self.explanation = explanation
-        self.resolution = resolution
+        self.example = multiline(example)
+        self.explanation = multiline(explanation)
+        self.resolution = multiline(resolution)
         self.remove = remove
         if zplog:
             self.LOG = zplog

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/EventClassSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/EventClassSpec.py
@@ -6,7 +6,7 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
-
+from ..base.types import multiline
 from .OrganizerSpec import OrganizerSpec
 from .EventClassMappingSpec import EventClassMappingSpec
 
@@ -29,7 +29,7 @@ class EventClassSpec(OrganizerSpec):
           :param description: Description of the EventClass
           :type description: str
           :param transform: EventClass Transformation
-          :type transform: str
+          :type transform: multiline
           :param mappings: TODO
           :type mappings: SpecsParameter(EventClassMappingSpec)
         """
@@ -42,7 +42,7 @@ class EventClassSpec(OrganizerSpec):
             self.LOG = zplog
 
         self.description = description
-        self.transform = transform
+        self.transform = multiline(transform)
         self.remove = bool(remove)
         self.mappings = self.specs_from_param(
             EventClassMappingSpec, 'mappings', mappings, zplog=self.LOG)

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_event_class_export.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_event_class_export.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+"""
+    Test Event Classes
+"""
+
+from ZenPacks.zenoss.ZenPackLib.tests.ZPLTestBase import ZPLTestBase
+from ZenPacks.zenoss.ZenPackLib.lib.helpers.utils import compare_zenpackspecs
+
+YAML_DOC = """
+name: ZenPacks.zenoss.ZenPackLib
+event_classes:
+  /Status/Test:
+    remove: false
+    description: Test event class
+    transform: "from ZenPacks.zenoss.CiscoMonitor import transforms\\ntransforms.status_handler(device, component, evt)"
+    mappings:
+      TestMapping:
+        eventClassKey: TestMapping
+        sequence:  10
+        example: Test Mapping example
+        explanation: This is a test for an example mapping
+        resolution: This is the resolution for the test mapping
+        remove: true
+        regex: +.*
+        transform: "from ZenPacks.zenoss.CiscoMonitor import transforms\\ntransforms.status_handler(device, component, evt)"
+        rule: "component.id == id"
+"""
+
+EXPECTED = """name: ZenPacks.zenoss.ZenPackLib
+event_classes:
+  /Status/Test:
+    description: Test event class
+    transform: |-
+      from ZenPacks.zenoss.CiscoMonitor import transforms
+      transforms.status_handler(device, component, evt)
+    mappings:
+      TestMapping:
+        eventClassKey: TestMapping
+        sequence: 10
+        rule: component.id == id
+        regex: +.*
+        transform: |-
+          from ZenPacks.zenoss.CiscoMonitor import transforms
+          transforms.status_handler(device, component, evt)
+        example: Test Mapping example
+        explanation: This is a test for an example mapping
+        resolution: This is the resolution for the test mapping
+        remove: true
+"""
+
+
+class TestEventClass(ZPLTestBase):
+    """Test Event Classes
+    """
+    yaml_doc = YAML_DOC
+
+    def test_exported_multiline(self):
+        self.assertEquals(self.z.exported_yaml,
+                          EXPECTED,
+                          'Multi-line export differs from expected:\n{}\ngot:\n{}'.format(
+                                                                  EXPECTED,
+                                                                  self.z.exported_yaml))
+
+
+def test_suite():
+    """Return test suite for this module."""
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestEventClass))
+    return suite
+
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()

--- a/docs/yaml-event-classes.rst
+++ b/docs/yaml-event-classes.rst
@@ -8,6 +8,13 @@ Event Classes are used to group together specific types of events.  This can be 
 
 To define a class, supply the path to the class or classes.  Then, for each event class, supply the appropriate properties for the class.  These include the option to remove the event class during ZenPack installation/uninstallation, description, and a transform.  You can also define mappings to apply to events based on a key and supply an explanation and/or resolution to an issue.
 
+
+.. note::
+
+     When you define an event class and/or mapping which already exists, any settings defined in your ZenPack 
+     will overwrite existing settings.
+
+
 The following example shows an example of a `zenpack.yaml` file with an example of a definition of an event class.
 
 .. code-block:: yaml
@@ -23,12 +30,22 @@ The following example shows an example of a `zenpack.yaml` file with an example 
             eventClassKey: WidgetEvent
             sequence:  10
             remove: true
-            transform: "if evt.message.find('Error reading value for') >= 0:\n\
-              \   evt._action = 'drop'"
+            transform: |-
+              if evt.message.find('Error reading value for') >= 0:
+                  evt._action = 'drop'
 
 .. note::
 
-  When you define an event class and/or mapping which already exists, any settings defined in your ZenPack will overwrite existing settings.
+     When assigning values to multi-line fields such as **transform** or **example**, the best way to preserve whitespace 
+     and readability is to use the 
+     
+     **transform: \|-**
+       **if evt.message.find('Error reading value for') >= 0:**
+           **evt._action = 'drop'**
+     
+     style convention demonstrated.  As this example demonstrates, the indented line following
+     the **"\|-"** style character becomes the first line of the transform, with subsequent whitespace preserved.
+
 
 .. _event-class-fields:
 
@@ -59,7 +76,7 @@ remove
 transform
   :Description: A python expression for transformation.
   :Required: No
-  :Type: string
+  :Type: string (multiline)
   :Default Value: None
 
 mappings
@@ -92,13 +109,13 @@ explanation
   :Description:
     Textual description for matches of this event class mapping. Use in conjunction with the Resolution field.
   :Required: No
-  :Type: string
+  :Type: string (multiline)
   :Default Value: None
 
 resolution
   :Description: Use the Resolution field to enter resolution instructions for clearing the event.
   :Required: No
-  :Type: string
+  :Type: string (multiline)
   :Default Value: None
 
 sequence
@@ -122,13 +139,13 @@ regex
 transform
   :Description: A python expression for transformation.
   :Required: No
-  :Type: string
+  :Type: string (multiline)
   :Default Value: None
 
 example
   :Description: Debugging string to use in the regular expression ui testing.
   :Required: No
-  :Type: string
+  :Type: string (multiline)
   :Default Value: None
 
 remove


### PR DESCRIPTION
- Added custom type for multi-line string to types.py
- Added custom representer and dumper for multi-line-strings
- Updated EventClassSpec(Params) and EventClassMappingSpec(Params) to
use multi-line strings for relevant attributes (description, transform,
example, explanation, resolution)
- Added test_event_class_export.py unit test
- Updated documentation with notes about multi-line handling and about
overriding existing properties