### PR TITLE
Fix potential POSKeyError during modeling

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/base/ComponentBase.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/base/ComponentBase.py
@@ -49,6 +49,17 @@ class ComponentBase(ModelBase):
 
     def __setattr__(self, name, value):
         '''enforce type checking when setting _properties attributes'''
+        if self._p_setattr(name, value):
+            # See documentation on overriding the attribute protocol for
+            # persistent objects. The self object here may be a ghost which
+            # would result in the call to self._properties below raising a
+            # POSKeyError. By first calling self._p_setattr, we can have the
+            # various _p_* properties handled correctly, and having the object
+            # activated (unghosted) when necessary.
+            #
+            # http://persistent.readthedocs.io/en/latest/using.html
+            return
+
         def lines(val):
             """handle 'lines' type"""
             if not isinstance(val, list):
@@ -77,7 +88,7 @@ class ComponentBase(ModelBase):
                                                                                         target_class.__name__,
                                                                                         value,
                                                                                         e))
-        super(ModelBase, self).__setattr__(name, value)
+        return super(ModelBase, self).__setattr__(name, value)
 
     def device(self):
         """Return device under which this component/device is contained."""

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -24,6 +24,13 @@ Backwards Incompatible Changes
 
 * zProperties will not be updated automatically on existing device classes.  These should be handled on a case basis by using migrate scripts.
 
+Release 2.0.8
+-------------
+
+Fixes
+
+* Fix potential POSKeyError when modeling devices. (ZPS-2371)
+
 Release 2.0.7
 -------------
 


### PR DESCRIPTION
In some cases the @transact decorator on
ModelerService.remote_applyDataMaps would result in the underlying
transaction code attempting to set the _p_estimated_size property on
persistent objects such as a NutanixVM. This would result in a
POSKeyError because at this opint the NutanixVM object would be a
"ghost" in ZODB persistent parlance, and not have the _properties
property that ComponentBase's __setattr__ attempted to use.

It turns out that the ZODB persistent module documentation specifically
covers this problem in what you need to do when overriding the attribute
protocol (__setattr__ among others) on persistent object classes.

http://persistent.readthedocs.io/en/latest/using.html#overriding-the-attribute-protocol

You must first call self._p_setattr(name, value) to unghost (or
activate) the object if necessary.

The modeling POSKeyError traceback in this one case follows.

    Traceback (most recent call last):
      File "../apply-zenmodeler-results", line 259, in <module>
        Script().run()
      File "../apply-zenmodeler-results", line 120, in run
        self.processDevice(device_id, grouped_results[device_id])
      File "../apply-zenmodeler-results", line 197, in processDevice
        self.apply(device, plugin_name, datamaps)
      File "../apply-zenmodeler-results", line 241, in apply
        self.service.remote_applyDataMaps(device.id, datamaps)
      File "/mnt/src/ZenPacks.zenoss.Layer2/ZenPacks/zenoss/Layer2/patches.py", line 110, in remote_applyDataMaps
        changed = original(self, device, maps, *args, **kwargs)
      File "/opt/zenoss/lib/python2.7/site-packages/ZODB/transact.py", line 51, in g
        _commit(note)
      File "/opt/zenoss/lib/python2.7/site-packages/ZODB/transact.py", line 23, in _commit
        t.commit()
      File "/opt/zenoss/lib/python2.7/site-packages/transaction/_transaction.py", line 329, in commit
        self._commitResources()
      File "/opt/zenoss/lib/python2.7/site-packages/transaction/_transaction.py", line 443, in _commitResources
        rm.commit(self)
      File "/opt/zenoss/lib/python2.7/site-packages/ZODB/Connection.py", line 562, in commit
        self._commit_savepoint(transaction)
      File "/opt/zenoss/lib/python2.7/site-packages/ZODB/Connection.py", line 1172, in _commit_savepoint
        obj._p_estimated_size = len(data)
      File "/mnt/src/ZenPacks.zenoss.ZenPackLib/ZenPacks/zenoss/ZenPackLib/lib/base/ComponentBase.py", line 67, in __setattr__
        property_dict = {p.get('id'): p.get('type') for p in self._properties}
      File "/opt/zenoss/lib/python2.7/site-packages/ZODB/Connection.py", line 860, in setstate
        self._setstate(obj)
      File "/opt/zenoss/lib/python2.7/site-packages/ZODB/Connection.py", line 901, in _setstate
        p, serial = self._storage.load(obj._p_oid, '')
      File "/opt/zenoss/lib/python2.7/site-packages/relstorage/storage.py", line 476, in load
        raise POSKeyError(oid)
    ZODB.POSException.POSKeyError: 0x2efb54

Fixes ZPS-2371.