### PR TITLE
Add support for "ABSOLUTE" Datapoint rrdtype (ZPS-2375)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDDatapointSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDDatapointSpec.py
@@ -157,7 +157,7 @@ class RRDDatapointSpec(Spec):
 
     @rrdtype.setter
     def rrdtype(self, value):
-        valid_types = ['GAUGE', 'DERIVE', 'COUNTER', 'RAW']
+        valid_types = ['GAUGE', 'DERIVE', 'COUNTER', 'RAW', 'ABSOLUTE']
         if not value:
             value = 'GAUGE'
         if str(value).upper() not in valid_types:

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_datapoint_shorthand.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_datapoint_shorthand.py
@@ -47,6 +47,21 @@ device_classes:
                 rrdtype: DERIVE
                 rrdmin: 0
                 aliases: {dp_aliased_alt: null}
+              dp_aliased_4: 
+                rrdtype: COUNTER
+                rrdmin: 0
+                rrdmax: 100
+                aliases: {dp_aliased_4: null}
+              dp_aliased_5: 
+                rrdtype: RAW
+                rrdmin: 0
+                rrdmax: 100
+                aliases: {dp_aliased_5: null}
+              dp_aliased_6: 
+                rrdtype: ABSOLUTE
+                rrdmin: 0
+                rrdmax: 100
+                aliases: {dp_aliased_6: null}
             oid: 1.3.6.1.4.1.2021.10.1.5.2
 """
 
@@ -75,6 +90,9 @@ device_classes:
                 rrdtype: DERIVE
                 rrdmin: 0
                 aliases: {dp_aliased_alt: null}
+              dp_aliased_4: COUNTER_MIN_0_MAX_100_ALIAS
+              dp_aliased_5: RAW_MIN_0_MAX_100_ALIAS
+              dp_aliased_6: ABSOLUTE_MIN_0_MAX_100_ALIAS
             oid: 1.3.6.1.4.1.2021.10.1.5.2
 """
 


### PR DESCRIPTION
- Fixes ZPS-2375
- Added 'ABSOLUTE' to the list of acceptable datapoint types
- Updated test_datapoint_shorthand to include additional test conditions