### PR TITLE
Fix failing unit test for impact triggers (ZPS-2271)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/tests/ZPLTestBase.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/ZPLTestBase.py
@@ -132,13 +132,14 @@ class ZPLTestMockZenPack(BaseTestCase):
     yaml_doc = '''name: ZenPacks.zenoss.ZenPackLib'''
     zenpack_name = 'ZenPacks.zenoss.MockZenPack'
     disableLogging = True
-    datsources = []
-    thresholds = []
 
-    def afterSetUp(self):
+    def afterSetUp(self, datasources=None, thresholds=None):
         super(ZPLTestMockZenPack, self).afterSetUp()
-
-        self.zenpack = MockZenPack(self.dmd, self.zenpack_name, datasources=self.datasources, thresholds=self.thresholds)
+        if datasources is None:
+            datasources = []
+        if thresholds is None:
+            thresholds = []
+        self.zenpack = MockZenPack(self.dmd, self.zenpack_name, datasources=datasources, thresholds=thresholds)
         # for a list of docs, iterate through
         if isinstance(self.yaml_doc, list):
             counter = 0
@@ -163,9 +164,13 @@ class ZPLTestMockZenPack(BaseTestCase):
 
 class MockZenPack(object):
     ''''''
-    def __init__(self, dmd, name, datasources=[], thresholds=[]):
+    def __init__(self, dmd, name, datasources=None, thresholds=None):
         self.dmd = dmd
         self.name = name
+        if datasources is None:
+            datasources = []
+        if thresholds is None:
+            thresholds = []
         self.datasources = datasources
         self.thresholds = thresholds
         self.install_zenpack()

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_extra_params_types.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_extra_params_types.py
@@ -88,11 +88,9 @@ class TestExtraParamsTypeHandling(ZPLTestMockZenPack):
     """
     yaml_doc = YAML_DOC
     disableLogging = False
-    thresholds = [CustomThreshold]
-    datasources = [CustomDatasource]
 
     def afterSetUp(self):
-        super(TestExtraParamsTypeHandling, self).afterSetUp()
+        super(TestExtraParamsTypeHandling, self).afterSetUp([CustomDatasource], [CustomThreshold])
         self.template = self.z.cfg.device_classes.get('/Devices').templates.get('TESTTEMPLATE').create(self.dmd, False)
 
     def test_inherited_defaults(self):


### PR DESCRIPTION
- Fixes ZPS-2271
- Rewrote test_impact_triggers to fix failure
- Also removed implicit zope connection that can cause build failures