### PR TITLE
Updated documentation (ZPS-1999)

### DIFF
--- a/docs/yaml-zProperties.rst
+++ b/docs/yaml-zProperties.rst
@@ -110,14 +110,12 @@ type
       Type of property. Valid types:
 
       * `boolean`
-      * `date`
       * `float`
       * `int`
       * `lines`
       * `long`
       * `password`
       * `string`
-      * `selection`
 
   :Required: No
   :Type: string


### PR DESCRIPTION
- Updated zProperties documentation which falsely indicated support for
"selection" and "date" types