### PR TITLE
Catch exception due to missing threshold zenpack

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
@@ -300,9 +300,14 @@ class ZenPack(ZenPackBase):
 
         # get YAML representation of prototype
         proto_id = '{}-new'.format(spec.name)
-        proto_object = spec.create(app.zport.dmd, False, proto_id)
-        proto_object_param = specparam.fromObject(proto_object)
-        proto_object_yaml = yaml.dump(proto_object_param, Dumper=Dumper)
+        try:
+            proto_object = spec.create(app.zport.dmd, False, proto_id)
+            proto_object_param = specparam.fromObject(proto_object)
+            proto_object_yaml = yaml.dump(proto_object_param, Dumper=Dumper)
+        except ValueError as err:
+            self.LOG.error( "Unable to create prototype object: %s", err.message)
+            return None
+
         spec.remove(app.zport.dmd, proto_id)
 
         return self.get_yaml_diff(object_yaml, proto_object_yaml)


### PR DESCRIPTION
Fixes ZPS-1732

Thresholds can be optional, like capacity threshold. If the threshold
ZP is not installed, and a ZP requests the particular threshold type,
then zenoss should just ignore the request, and the logger should
generate an error message.