### PR TITLE
Truncate ZP install logging regarding template changes (ZPS-1520)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
@@ -208,8 +208,8 @@ class ZenPack(ZenPackBase):
                  "the newer version included with the {} ZenPack.  "
                  "The existing object will be "
                  "backed up to '{}'.  Please review and reconcile any "
-                 "local changes before deleting the backup:\n{}".format(
-                    parent.getDmdKey(), object.id, self.id, preupgrade_id, diff))
+                 "local changes before deleting the backup".format(
+                    parent.getDmdKey(), spec.name, self.id, preupgrade_id))
         return True
 
     def get_object(self, parent, relname, object_id):


### PR DESCRIPTION
- Fixes ZPS-1520
- remove YAML diff from logging output, and corrected initial reference
to template name in log message