### PR TITLE
Fix missing import of Jobber

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/tests/TestCase.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/tests/TestCase.py
@@ -78,8 +78,13 @@ class TestCase(BaseTestCase):
             pass
 
         try:
-            import ZenPacks.zenoss.Impact
+            import Products.Jobber
             zcml.load_config('meta.zcml', Products.Jobber)
+        except ImportError:
+            pass
+
+        try:
+            import ZenPacks.zenoss.Impact
             zcml.load_config('meta.zcml', ZenPacks.zenoss.Impact)
             zcml.load_config('configure.zcml', ZenPacks.zenoss.Impact)
         except ImportError:

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_testing.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_testing.py
@@ -1,0 +1,41 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import ZenPacks.zenoss.ZenPackLib
+from ZenPacks.zenoss.ZenPackLib import zenpacklib
+from ZenPacks.zenoss.ZenPackLib.lib.tests.TestCase import TestCase as LibTestCase
+from ZenPacks.zenoss.ZenPackLib.lib.spec.ZenPackSpec import ZenPackSpec
+
+zenpacklib.enableTesting()
+
+
+class TestTestCase(zenpacklib.TestCase):
+    def afterSetUp(self):
+        ZenPacks.zenoss.ZenPackLib.CFG = ZenPackSpec("ZenPacks.zenoss.ZenPackLib")
+        super(TestTestCase, self).afterSetUp()
+
+    def beforeTearDown(self):
+        del(ZenPacks.zenoss.ZenPackLib.CFG)
+
+    def test_nothing(self):
+        self.assertTrue(True)
+
+
+class TestLibTestCase(LibTestCase):
+    zenpack_module_name = "ZenPacks.zenoss.ZenPackLib"
+
+    def afterSetUp(self):
+        ZenPacks.zenoss.ZenPackLib.CFG = ZenPackSpec("ZenPacks.zenoss.ZenPackLib")
+        super(TestLibTestCase, self).afterSetUp()
+
+    def beforeTearDown(self):
+        del(ZenPacks.zenoss.ZenPackLib.CFG)
+
+    def test_nothing(self):
+        self.assertTrue(True)

--- a/ZenPacks/zenoss/ZenPackLib/zenpacklib.py
+++ b/ZenPacks/zenoss/ZenPackLib/zenpacklib.py
@@ -131,8 +131,13 @@ def enableTesting():
                 pass
 
             try:
-                import ZenPacks.zenoss.Impact
+                import Products.Jobber
                 zcml.load_config('meta.zcml', Products.Jobber)
+            except ImportError:
+                pass
+
+            try:
+                import ZenPacks.zenoss.Impact
                 zcml.load_config('meta.zcml', ZenPacks.zenoss.Impact)
                 zcml.load_config('configure.zcml', ZenPacks.zenoss.Impact)
             except ImportError:


### PR DESCRIPTION
Products.Jobber was used without being imported. Also added very basic
unit tests to make sure zenpacklib.TestCase can be used as a base test
case by other ZenPacks.

Fixes ZPS-2011.