### PR TITLE
Revert adding organizers to ZenPack.packables

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
@@ -272,6 +272,14 @@ class ZenPack(ZenPackBase):
             except KeyError:
                 self.LOG.warning('Unable to find {} {}'.format(dmd_root.__class__.__name__, cspec.path))
                 continue
+
+            # Anything left in packables will be removed the platform.
+            try:
+                self.packables.removeRelation(organizer)
+            except Exception:
+                # The organizer wasn't in packables.
+                pass
+
             if cspec.remove and hasattr(organizer, 'zpl_managed') and organizer.zpl_managed:
                 # make sure the organizer is zpl_managed before we try and delete it
                 # also double-check that we do not remove anything important like /Status or Processes

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/EventClassSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/EventClassSpec.py
@@ -47,16 +47,11 @@ class EventClassSpec(OrganizerSpec):
         self.mappings = self.specs_from_param(
             EventClassMappingSpec, 'mappings', mappings, zplog=self.LOG)
 
-    def instantiate(self, dmd, addToZenPack=True):
+    def instantiate(self, dmd):
         ecObject = self.get_organizer(dmd)
         if not ecObject:
             ecObject = dmd.Events.createOrganizer(self.path)
             ecObject.zpl_managed = True
-
-        # Set to false to facilitate testing without ZP installation.
-        if addToZenPack:
-            # Add this EventClass to the zenpack.
-            ecObject.addToZenPack(pack=self.zenpack_spec.name)
 
         if self.description != '':
             if not ecObject.description == self.description:

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ProcessClassOrganizerSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ProcessClassOrganizerSpec.py
@@ -43,16 +43,11 @@ class ProcessClassOrganizerSpec(OrganizerSpec):
         self.process_classes = self.specs_from_param(
             ProcessClassSpec, 'process_classes', process_classes, zplog=self.LOG)
 
-    def create(self, dmd, addToZenPack=True):
+    def create(self, dmd):
         porg = self.get_organizer(dmd)
         if not porg:
             porg = dmd.Processes.createOrganizer(self.path)
             porg.zpl_managed = True
-
-        # Set to false to facilitate testing without ZP installation.
-        if addToZenPack:
-             # Add this OSProcessOrganizer to the zenpack.
-            porg.addToZenPack(pack=self.zenpack_spec.name)
 
         if porg.description != self.description:
             porg.description = self.description

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -24,6 +24,14 @@ Backwards Incompatible Changes
 
 * zProperties will not be updated automatically on existing device classes.  These should be handled on a case basis by using migrate scripts.
 
+Release 2.0.9
+-------------
+
+Fixes
+
+* Fix incorrect removal of organizers such as /Status event class (ZPS-2660)
+
+
 Release 2.0.8
 -------------
 
@@ -35,6 +43,7 @@ Fixes
 * Improved component path reporters for mixin platform proxy classes (ZPS-1262)
 * Fix zenpacklib.TestCase when Impact >= 5.2.2 is installed (ZPS-2011)
 
+
 Release 2.0.7
 -------------
 
@@ -42,6 +51,7 @@ Fixes
 
 * Fix all the zenpacklib dump options. (ZPS-1601)
 * Implement template replacement and addition on device level. (ZPS-1704)
+
 
 Release 2.0.6
 -------------
@@ -54,6 +64,7 @@ Fixes
 * Fix GUI ZenPack export of objects.xml (ZPS-1589)
 * Fix datapoint alias shorthand export handling (ZPS-1589)
 
+
 Release 2.0.5
 -------------
 
@@ -63,6 +74,7 @@ Fixes
 * Template backups use YYYYMMDDHHMM format instead of unix timestamp.
 * Fix failure to back up customized templates during upgrade from pre-2.0 ZenPacks. (ZPS-1195)
 * Fix failure to back up customized templates during upgrade. (ZPS-1176)
+
 
 Release 2.0.4
 -------------

--- a/docs/command-line-reference.rst
+++ b/docs/command-line-reference.rst
@@ -225,6 +225,11 @@ mappings already loaded into your Zenoss instance and associated with a ZenPack.
 will export them to the YAML format required for `zenpack.yaml`. It is up to you to merge
 that YAML with your existing `zenpack.yaml`. file.
 
+Only event classes sourced from the ZenPack's XML will be exported. Any
+event classes sourced from the ZenPack's YAML will not be exported. If the
+YAML for these event classes is desired, it should be copied from the
+ZenPack's existing YAML.
+
 Example usage:
 
 .. code-block:: bash
@@ -250,6 +255,11 @@ The *---dump-process-classes* switch is designed to export process class organiz
 classes already loaded into your Zenoss instance and associated with a ZenPack. It 
 will export them to the YAML format required for `zenpack.yaml`. It is up to you to merge
 that YAML with your existing `zenpack.yaml`. file.
+
+Only process class organizers sourced from the ZenPack's XML will be
+exported. Any process class organizers sourced from the ZenPack's YAML will
+not be exported. If the YAML for these process class organizers is desired,
+it should be copied from the ZenPack's existing YAML.
 
 Example usage:
 


### PR DESCRIPTION
Adding orgnanizers such as event classes and process class organizers to
the ZenPack's packables results in them being removed from Zenoss when
the ZenPack is removed. This is the case even if the YAML explicitely
sets `remove: true`.

This reverts commit 1c8ee3454d6201534a21768c9e6c28c3a16a19ac.

Fixes ZPS-2660.