### PR TITLE
Make most unit tests optional (ZPS-3035)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/tests/ZPLTestBase.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/ZPLTestBase.py
@@ -30,6 +30,12 @@ from ZenPacks.zenoss.ZenPackLib.tests.ZPLTestHarness import ZPLTestHarness
 from ZenPacks.zenoss.ZenPackLib.lib.helpers.loaders import WarningLoader
 from ZenPacks.zenoss.ZenPackLib.lib.helpers.ZenPackLibLog import ZPLOG
 
+RUN_TESTS = False
+if os.getenv('RUN_BROKEN_TESTS'):
+    RUN_TESTS = True
+else:
+    print "Set RUN_BROKEN_TESTS environment variable to enable unit testing"
+
 
 class ZPLTestBase(BaseTestCase):
     """BaseTestCase class with ZPLTestHarness support"""
@@ -37,6 +43,15 @@ class ZPLTestBase(BaseTestCase):
     yaml_doc = '''name: ZenPacks.zenoss.ZenPackLib'''
     disableLogging = True
     z = None
+
+    def setUp(self):
+        if not RUN_TESTS:
+            msg = (
+                "Skipping {} because environment "
+                "variable RUN_BROKEN_TESTS is unset"
+                ).format(self.__class__.__name__)
+            self.skipTest(msg)
+        super(ZPLTestBase, self).setUp()
 
     def afterSetUp(self):
         super(ZPLTestBase, self).afterSetUp()


### PR DESCRIPTION
- Fixes ZPS-3035
- This is a temporary change until ZPLTestBase and associated classes
are redesigned to avoid automated build issues (ZPS-3035)
- Unit tests are skipped unless the "RUN_ZPL_TESTS" environment variable
is set beforehand
- Updated __version__ in zenpacklib.py to 2.0.10