### PR TITLE
Add default "capacity_get_threshold_configs" method to ZenPack.py

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
@@ -501,3 +501,38 @@ class ZenPack(ZenPackBase):
 
         except Exception, e:
             self.LOG.error("Unable to postprocess {}: {}".format(filename, e))
+
+    def capacity_get_threshold_configs(self):
+        """Describe Capacity thresholds for this ZenPack.
+        Described here so that they can be installed when Capacity is
+        installed before or after this ZenPack is installed, and so that
+        this ZenPack doesn't require the Capacity ZenPack to be installed.
+        Note that these thresholds are only installed if they don't already
+        exist. Any changes needed to these thresholds when upgrading from
+        one version of this ZenPack to another must be done with migrate
+        steps.
+        The Capacity ZenPack is responsible for calling this method at the
+        appropriate times. The Capacity ZenPack is also responsible for
+        removing these thresholds prior to the Capacity ZenPack being
+        uninstalled.
+        """
+        configs = []
+        for dc_name, dc_spec in self.device_classes.iteritems():
+            for t_name, t_spec in dc_spec.templates.iteritems():
+                for th_name, th_spec in t_spec.thresholds.iteritems():
+                    if th_spec.type_ != 'CapacityThreshold':
+                        continue
+
+                    th_config = {'deviceclass': dc_name,
+                                 'template': t_name,
+                                 'name': th_name,
+                                 'dsnames': getattr(th_spec, 'dsnames', [])}
+
+                    for x in ['eventClass', 'severity', 'enabled']:
+                        if getattr(th_spec, x) is not None:
+                            th_config[x] = getattr(th_spec, x)
+
+                    th_config.update(getattr(th_spec, 'extra_params', {}))
+
+                    configs.append(th_config)
+        return configs

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDTemplateSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDTemplateSpec.py
@@ -6,10 +6,14 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
+from collections import OrderedDict
 from .Spec import Spec
 from .RRDThresholdSpec import RRDThresholdSpec
 from .RRDDatasourceSpec import RRDDatasourceSpec
 from .GraphDefinitionSpec import GraphDefinitionSpec
+from ..utils import capacity_installed
+
+CAPACITY_INSTALLED = capacity_installed()
 
 
 class RRDTemplateSpec(Spec):
@@ -51,6 +55,13 @@ class RRDTemplateSpec(Spec):
         self.name = name
         self.description = description
         self.targetPythonClass = targetPythonClass
+
+        # Capacity thresholds are special and should be installable before or after
+        # the particular ZenPack using them
+        if isinstance(thresholds, dict) and not CAPACITY_INSTALLED:
+            thresholds = OrderedDict(
+                [(k, v) for k, v in thresholds.items()
+                 if v.get('type_') != 'CapacityThreshold'])
 
         self.thresholds = self.specs_from_param(
             RRDThresholdSpec, 'thresholds', thresholds, zplog=self.LOG)

--- a/ZenPacks/zenoss/ZenPackLib/lib/utils.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/utils.py
@@ -8,7 +8,6 @@
 ##############################################################################
 from .helpers.ZenPackLibLog import DEFAULTLOG
 
-
 FACET_BLACKLIST = (
     'dependencies',
     'dependents',
@@ -16,7 +15,6 @@ FACET_BLACKLIST = (
     'pack',
     'productClass',
     )
-
 
 # ## functions to determine conditional imports elsewhere
 
@@ -67,6 +65,18 @@ def has_metricfacade():
         from Products.Zuul.facades import metricfacade
     except ImportError:
         DEFAULTLOG.debug('MetricFacade is not available and some functionality dependent on it will be disabled')
+        pass
+    else:
+        return True
+    return False
+
+
+def capacity_installed():
+    """Return True if Capacity ZenPack is installed"""
+    try:
+        from ZenPacks.zenoss.Capacity import CFG
+    except ImportError:
+        DEFAULTLOG.debug('Capacity ZenPack is not installed and some functionality dependent on it will be disabled')
         pass
     else:
         return True

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_capacity_thresholds.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_capacity_thresholds.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2018, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+""" 
+    Verify that Capacity Thresholds are handled whether or not Capacity ZenPack is installed
+"""
+
+from ZenPacks.zenoss.ZenPackLib.tests import ZPLBaseTestCase
+import ZenPacks.zenoss.ZenPackLib.lib.spec.RRDTemplateSpec
+
+YAML_DOC = """
+name: ZenPacks.zenoss.UsesCapacityThresholds
+device_classes:
+  /Devices:
+    templates:
+      Template:
+        datasources:
+          stats:
+            type: SNMP
+            oid: 1.3.6.1.4.1.2021.10.1.5.2
+            datapoints:
+              used: GAUGE
+              total: GAUGE
+        thresholds:
+          storage_capacity:
+            type: CapacityThreshold
+            eventClass: /Capacity/Storage
+            dsnames: [stats_used, stats_total]
+            capacity_type: storage
+            total_expression: stats_used
+            used_expression: stats_total
+            pct_threshold: 99.0
+"""
+
+
+class TestCapacityThresholds(ZPLBaseTestCase):
+    """ Test that custom datasource/threshold class attributes are handled correctly"""
+
+    yaml_doc = YAML_DOC
+
+    def test_without_capacity(self):
+        """Verify that thresholds are removed if Capacity ZenPack is not installed"""
+        ZenPacks.zenoss.ZenPackLib.lib.spec.RRDTemplateSpec.CAPACITY_INSTALLED = False
+        num_thresholds = self.get_num_thresholds()
+        self.assertEqual(
+            num_thresholds, 0,
+            'Expected {} capacity threshold, got {}'.format(0, num_thresholds)),
+
+    def test_with_capacity(self):
+        """Verify that thresholds are removed if Capacity ZenPack is installed"""
+        ZenPacks.zenoss.ZenPackLib.lib.spec.RRDTemplateSpec.CAPACITY_INSTALLED = True
+        num_thresholds = self.get_num_thresholds()
+        self.assertEqual(
+            num_thresholds, 1,
+            'Expected {} capacity threshold, got {}'.format(1, num_thresholds)),
+
+    def get_num_thresholds(self):
+        self.initialize(self.yaml_doc)
+        config = self.configs.get('ZenPacks.zenoss.UsesCapacityThresholds')
+        cfg = config.get('cfg')
+        thresholds = cfg.device_classes.get(
+            '/Devices').templates.get('Template').thresholds
+        return len(thresholds.keys())
+
+
+def test_suite():
+    """Return test suite for this module."""
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestCapacityThresholds))
+    return suite
+
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()

--- a/docs/yaml-monitoring-templates.rst
+++ b/docs/yaml-monitoring-templates.rst
@@ -588,6 +588,31 @@ ValueChangeThreshold
   :Availability: Zenoss Platform
   :Additional Fields: None
 
+CapacityThreshold
+  :Description:  Can be defined whether or not Capacity ZenPack is installed.  Please refer to ZenPack documentation for further details.
+  :Availability: Capacity ZenPack
+  :Additional Fields:
+    capacity_type
+      :Description: Must be one of cpu, memory, network, storage.
+      :Required: No
+      :Type: string 
+      :Default Value: None
+    total_expression
+      :Description: Python expression that must return the total capacity in native units.
+      :Required: No
+      :Type: string 
+      :Default Value: None
+    used_expression
+      :Description: Python expression that must return the currently used capacity in native units.
+      :Required: No
+      :Type: string 
+      :Default Value: None
+    pct_threshold
+      :Description: At what percentage (0-100) used of total is the threshold considered exceeded.
+      :Required: No
+      :Type: float 
+      :Default Value: None
+
 .. _graph-fields:
 
 Graph Fields


### PR DESCRIPTION
- This should facilitate automatic generation of Capacity ZP thresholds
for the case when Capacity ZP is installed after a given ZP with
Capacity thresholds defined.