### PR TITLE
Don't allow invalid RRD data point type (ZPS-1733, ZPS-1734)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDDatapointSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDDatapointSpec.py
@@ -157,7 +157,7 @@ class RRDDatapointSpec(Spec):
 
     @rrdtype.setter
     def rrdtype(self, value):
-        valid_types = ['GAUGE', 'DERIVE', 'COUNTER', 'RAW']
+        valid_types = ['GAUGE', 'DERIVE', 'COUNTER', 'ABSOLUTE']
         if not value:
             value = 'GAUGE'
         if str(value).upper() not in valid_types:

--- a/docs/yaml-monitoring-templates.rst
+++ b/docs/yaml-monitoring-templates.rst
@@ -493,7 +493,7 @@ above list. This is because datapoints are an extensible type in Zenoss, and
 depending on the value of the datasource's *type*, other fields may be valid.
 
 YAML datapoint specification also supports the use of an alternate "shorthand" notation for brevity.  Shorthand 
-notation follows a pattern of `RRDTYPE_MIN_X_MAX_X` where RRDTYPE is one of "GAUGE, DERIVE, COUNTER, RAW", 
+notation follows a pattern of `RRDTYPE_MIN_X_MAX_X` where RRDTYPE is one of "GAUGE, DERIVE, COUNTER, ABSOLUTE", 
 and the "MIN_X"/"MAX_X" parameters are optional.  
 
 For example, DERIVE, DERIVE_MIN_0, and DERIVE_MIN_0_MAX_100 are all valid shorthand notation.


### PR DESCRIPTION
- Fixes ZPS-1733, ZPS-1734
- RAW was incorrectly allowed as a datapoint type
- Replaced RAW with ABSOLUTE in RRDDatapoint spec validation
- Updated documentation