### PR TITLE
Ensure that zenpacklib exports YAML as expected (ZPS-1746)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/YAMLExporter.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/YAMLExporter.py
@@ -1,0 +1,143 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+import yaml
+import collections
+from ..params.ZenPackSpecParams import ZenPackSpecParams
+from ..params.RRDTemplateSpecParams import RRDTemplateSpecParams
+from ..params.EventClassSpecParams import EventClassSpecParams
+from ..params.EventClassMappingSpecParams import EventClassMappingSpecParams
+from ..params.ProcessClassOrganizerSpecParams import ProcessClassOrganizerSpecParams
+from .Dumper import Dumper
+
+
+class YAMLExporter(object):
+    """
+        Class containing methods for exporting 
+        existing ZenPack objects to YAML
+    """
+
+    @staticmethod
+    def dump_templates(zenpack):
+        """Return YAML export of RRD Templates"""
+        zenpack_name = zenpack.id
+        templates = YAMLExporter.get_template_specparams(zenpack)
+        if not templates:
+            for dc_name, dc_sp in zenpack._v_specparams.device_classes.items():
+                templates.update({dc_name: dc_sp.templates})
+
+        if templates:
+            zpsp = ZenPackSpecParams(
+                zenpack_name,
+                device_classes={x: {} for x in templates})
+            for dc_name in templates:
+                zpsp.device_classes[dc_name].templates = templates[dc_name]
+
+            return yaml.dump(zpsp, Dumper=Dumper)
+
+    @staticmethod
+    def dump_event_classes(zenpack):
+        """Return YAML export of Event Classes"""
+        eventclasses = YAMLExporter.get_event_class_specparams(zenpack)
+        if not eventclasses:
+            eventclasses.update(zenpack._v_specparams.event_classes)
+        zenpack_name = zenpack.id
+        if eventclasses:
+            zpsp = ZenPackSpecParams(zenpack_name,
+                                     event_classes={x: {} for x in eventclasses})
+            for ec_name in eventclasses:
+                zpsp.event_classes[ec_name] = eventclasses[ec_name]
+                zpsp.event_classes[ec_name].mappings = eventclasses[ec_name].mappings
+
+            return yaml.dump(zpsp, Dumper=Dumper)
+
+    @staticmethod
+    def dump_process_classes(zenpack):
+        """Return YAML export of Process Classes"""
+        processclasses = YAMLExporter.get_process_class_specparams(zenpack)
+        if not processclasses:
+            processclasses.update(zenpack._v_specparams.process_class_organizers)
+        zenpack_name = zenpack.id
+        if processclasses:
+            zpsp = ZenPackSpecParams(zenpack_name,
+                                     process_class_organizers={x: {} for x in processclasses})
+            for pc_name in processclasses:
+                zpsp.process_class_organizers[pc_name].process_classes = processclasses[pc_name].process_classes
+
+            return yaml.dump(zpsp, Dumper=Dumper)
+
+    @staticmethod
+    def get_template_specparams(zenpack):
+        """Return dictionary of Template SpecParams"""
+        specs = collections.defaultdict(dict)
+
+        dc_packables = YAMLExporter.get_packables(
+            zenpack, 'DeviceClass')
+        rrd_packables = YAMLExporter.get_packables(
+            zenpack, 'RRDTemplate')
+
+        for template in set(
+            [x.getAllRRDTemplates() for x in dc_packables] + rrd_packables):
+            deviceClass = template.deviceClass()
+            if deviceClass:
+                dc_name = deviceClass.getOrganizerName()
+                specs[dc_name][template.id] = RRDTemplateSpecParams.fromObject(template)
+        return specs
+
+    @staticmethod
+    def get_event_class_specparams(zenpack):
+        """Return dictionary of EventClass SpecParams"""
+        ec_packables = YAMLExporter.get_packables(
+            zenpack, 'EventClass')
+
+        eventclasses = YAMLExporter.get_organizer_specparams(
+            ec_packables, EventClassSpecParams)
+
+        # get list of instances associated with event classes not already seen
+        inst_packables = YAMLExporter.get_packables(
+                zenpack, 'EventClassInst')
+
+        # list of unique event classes
+        inst_evs = list({x.eventClass() for x in inst_packables
+            if x.eventClass().getDmdKey() not in eventclasses})
+
+        for ev in inst_evs:
+            ec_name = ev.getDmdKey()
+            ev_spec = EventClassSpecParams.new(ec_name, remove=False)
+            ev_instances = [x for x in ev.instances() if x in zenpack.packables()]
+            ev_spec.mappings = { x.id: EventClassMappingSpecParams.fromObject(x) for x in ev_instances }
+            eventclasses[ec_name] = ev_spec
+
+        return eventclasses
+
+    @staticmethod
+    def get_process_class_specparams(zenpack):
+        """Return dictionary of EventClass SpecParams"""
+        from_packables = YAMLExporter.get_packables(
+            zenpack, 'OSProcessOrganizer')
+        return YAMLExporter.get_organizer_specparams(
+            from_packables, ProcessClassOrganizerSpecParams)
+
+    @staticmethod
+    def get_organizer_specparams(organizers, specparam_cls):
+        """Return organizer_related specparams"""
+        output = collections.defaultdict(dict)
+        for org in organizers:
+            name = org.getDmdKey()
+            # electing not to set remove=True here to avoid unwanted deletions
+            output[name] = specparam_cls.fromObject(org)
+            for sub_org in org.getSubOrganizers():
+                name = sub_org.getDmdKey()
+                output[name] = specparam_cls.fromObject(sub_org, remove=False)
+        return output
+
+    @staticmethod
+    def get_packables(zenpack, meta_type):
+        """Return objects of a given meta_type from a ZenPack's packables"""
+        return [x for x in zenpack.packables()
+            if x.meta_type == meta_type]

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/ProcessClassSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/ProcessClassSpecParams.py
@@ -49,7 +49,7 @@ class ProcessClassSpecParams(SpecParams, ProcessClassSpec):
         SpecParams.__init__(self)
         processclass = aq_base(processclass)
 
-        _properties = ['description', 'includeRegex', 'excludeRegex',
+        _properties = ['description', 'includeRegex', 'excludeRegex', 'replaceRegex',
                        'replacement', 'zMonitor', 'zAlertOnRestart',
                        'zFailSeverity', 'zModelerLock', 'zSendEventWhenBlockedFlag']
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/EventClassSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/EventClassSpec.py
@@ -13,6 +13,7 @@ from .EventClassMappingSpec import EventClassMappingSpec
 
 class EventClassSpec(OrganizerSpec):
     """Initialize a EventClass via Python at install time."""
+
     def __init__(
             self,
             zenpack_spec,
@@ -70,6 +71,7 @@ class EventClassSpec(OrganizerSpec):
 
         for mapping_id, mapping_spec in self.mappings.items():
             mapping_spec.create(ecObject)
+        return ecObject
 
     def get_root(self, dmd):
         """Return the root object for this organizer."""

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ProcessClassOrganizerSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ProcessClassOrganizerSpec.py
@@ -13,6 +13,7 @@ from .ProcessClassSpec import ProcessClassSpec
 
 class ProcessClassOrganizerSpec(OrganizerSpec):
     """Initialize a Process Set via Python at install time."""
+
     def __init__(
             self,
             zenpack_spec,
@@ -54,6 +55,7 @@ class ProcessClassOrganizerSpec(OrganizerSpec):
 
         for process_class_id, process_class_spec in self.process_classes.items():
             process_class_spec.create(dmd, porg)
+        return porg
 
     def get_root(self, dmd):
         """Return the root object for this organizer."""

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_yaml_export.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_yaml_export.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python
+
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2018, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+"""
+    Test that export of Zope objects works as expected
+"""
+from ZenPacks.zenoss.ZenPackLib.tests import ZPLBaseTestCase
+from ZenPacks.zenoss.ZenPackLib.lib.libexec.ZPLCommand import YAMLExporter
+
+YAML_DOC = '''
+name: ZenPacks.acme.Processes
+
+device_classes:
+  /ZPL/Test:
+    templates:
+      TestTemplate:
+        datasources:
+          ds0:
+            type: COMMAND
+            parser: Nagios
+            commandTemplate: echo OK|percent=100
+
+process_class_organizers:
+  /Widget:
+    description: Organizer for Widget process classes
+    process_classes:
+      widget:
+        description: Widget process class
+        includeRegex: sbin\/widget
+        excludeRegex: "\\b(vim|tail|grep|tar|cat|bash)\\b"
+        replaceRegex: .*
+        replacement: Widget
+
+event_classes:
+  /Status/Test:
+    remove: false
+    description: Test event class
+    transform: "from ZenPacks.zenoss.CiscoMonitor import transforms\\ntransforms.status_handler(device, component, evt)"
+    mappings:
+      TestMapping:
+        eventClassKey: TestMapping
+        sequence:  10
+        example: Test Mapping example
+        explanation: This is a test for an example mapping
+        resolution: This is the resolution for the test mapping
+        remove: true
+        regex: +.*
+        transform: "from ZenPacks.zenoss.CiscoMonitor import transforms\\ntransforms.status_handler(device, component, evt)"
+        rule: "component.id == id"
+'''
+
+T_YAML = '''name: ZenPacks.acme.Processes
+device_classes:
+  /ZPL/Test:
+    templates:
+      TestTemplate:
+        datasources:
+          ds0:
+            type: COMMAND
+            commandTemplate: echo OK|percent=100
+            parser: Nagios
+'''
+
+EV_YAML = '''name: ZenPacks.acme.Processes
+event_classes:
+  /Status/Test:
+    description: Test event class
+    transform: |-
+      from ZenPacks.zenoss.CiscoMonitor import transforms
+      transforms.status_handler(device, component, evt)
+    mappings:
+      TestMapping:
+        eventClassKey: TestMapping
+        sequence: 10
+        rule: component.id == id
+        regex: +.*
+        transform: |-
+          from ZenPacks.zenoss.CiscoMonitor import transforms
+          transforms.status_handler(device, component, evt)
+        example: Test Mapping example
+        explanation: This is a test for an example mapping
+        resolution: This is the resolution for the test mapping
+        remove: true
+'''
+
+EV_YAML_ZP = '''name: ZenPacks.acme.Processes
+event_classes:
+  /Status/Test:
+    description: Test event class
+    transform: |-
+      from ZenPacks.zenoss.CiscoMonitor import transforms
+      transforms.status_handler(device, component, evt)
+    mappings:
+      TestMapping:
+        eventClassKey: TestMapping
+        sequence: 10
+        rule: component.id == id
+        regex: +.*
+        transform: |-
+          from ZenPacks.zenoss.CiscoMonitor import transforms
+          transforms.status_handler(device, component, evt)
+        example: Test Mapping example
+        explanation: This is a test for an example mapping
+        resolution: This is the resolution for the test mapping
+'''
+
+PR_YAML = '''name: ZenPacks.acme.Processes
+process_class_organizers:
+  /Widget:
+    process_classes:
+      widget:
+        description: Widget process class
+        includeRegex: sbin\/widget
+        excludeRegex: "\\b(vim|tail|grep|tar|cat|bash)\\b"
+        replaceRegex: .*
+        replacement: Widget
+'''
+
+
+class TestZopeObjectExport(ZPLBaseTestCase):
+    """
+    Test that export of Zope objects works as expected
+    """
+    yaml_doc = [YAML_DOC]
+
+    def afterSetUp(self):
+        super(TestZopeObjectExport, self).afterSetUp()
+        config = self.configs.get('ZenPacks.acme.Processes')
+        self.cfg = config.get('cfg')
+        self.zenpack = config.get('zenpack')
+
+    def test_export_process_classes(self):
+        """Test export from ZPL-based ZenPacks"""
+        process_classes = YAMLExporter.dump_process_classes(self.zenpack)
+        diff = self.zenpack.get_yaml_diff(process_classes, PR_YAML)
+        self.assertEquals(
+            process_classes, PR_YAML,
+            'Expected:\n{}\ngot:\n{}'.format(PR_YAML, diff))
+
+    def test_export_process_classes_packable(self):
+        """Test dumping from legacy ZenPacks with packables"""
+        for psname, psspec in self.cfg.process_class_organizers.iteritems():
+            porg = psspec.create(self.app.zport.dmd)
+            try:
+                self.zenpack.packables.addRelation(porg)
+            except:
+                pass
+        process_classes = YAMLExporter.dump_process_classes(self.zenpack)
+        diff = self.zenpack.get_yaml_diff(PR_YAML, process_classes)
+        self.assertEquals(
+            process_classes, PR_YAML,
+            'Expected:\n{}\ngot:\n{}'.format(PR_YAML, diff))
+
+    def test_export_event_classes(self):
+        """Test export from ZPL-based ZenPacks"""
+        event_classes = YAMLExporter.dump_event_classes(self.zenpack)
+        diff = self.zenpack.get_yaml_diff(event_classes, EV_YAML)
+        self.assertEquals(
+            event_classes, EV_YAML,
+            'Expected:\n{}\ngot:\n{}'.format(EV_YAML, diff))
+
+    def test_export_event_classes_packable(self):
+        """Test export from ZPL-based ZenPacks"""
+        for ecname, ecspec in self.cfg.event_classes.iteritems():
+            ecorg = ecspec.instantiate(self.app.zport.dmd)
+            try:
+                self.zenpack.packables.addRelation(ecorg)
+            except:
+                pass
+        event_classes = YAMLExporter.dump_event_classes(self.zenpack)
+        diff = self.zenpack.get_yaml_diff(event_classes, EV_YAML_ZP)
+        self.assertEquals(
+            event_classes, EV_YAML_ZP,
+            'Expected:\n{}\ngot:\n{}'.format(EV_YAML_ZP, diff))
+
+    def test_export_templates(self):
+        """Test export from ZPL-based ZenPacks"""
+        templates = YAMLExporter.dump_templates(self.zenpack)
+        diff = self.zenpack.get_yaml_diff(templates, T_YAML)
+        self.assertEquals(
+             templates, T_YAML,
+            'Expected:\n{}\ngot:\n{}'.format(T_YAML, diff))
+
+
+def test_suite():
+    """Return test suite for this module."""
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestZopeObjectExport))
+    return suite
+
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()


### PR DESCRIPTION
- Fixes ZPS-1746
- Updated EventClassSpec and ProcessClassOrganizer spec
create/instantiate methods to return organizers
- Added missing 'replaceRegex' attribute to ProcessClassSpecParams
- Moved zenpack dumping methods to YAMLExport class mixin, where they
can be unit tested without calling ZenScriptBase or the command line
- Updated ZPLCommand to use YAMLExport methods for dumping
- Added test_yaml_export.py unit test