### PR TITLE
Input validation for class properties and ZProperties

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/Dumper.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/Dumper.py
@@ -8,24 +8,12 @@
 ##############################################################################
 import yaml
 import re
+from datetime import date, datetime
+from DateTime import DateTime
 from yaml.representer import SafeRepresenter
 from collections import OrderedDict
 from .ZenPackLibLog import DEFAULTLOG
-
-
-def get_zproperty_type(z_type):
-    """
-        For zproperties, the actual data type of a default value
-        depends on the defined type of the zProperty.
-    """
-    map = {'boolean': 'bool',
-           'int': 'int',
-           'float': 'float',
-           'string': 'str',
-           'password': 'str',
-           'lines': 'list(str)'
-    }
-    return map.get(z_type, 'str')
+from ..base.types import Property
 
 
 class Dumper(yaml.Dumper):
@@ -152,7 +140,7 @@ class Dumper(yaml.Dumper):
             if type_ == 'ZPropertyDefaultValue':
                 # For zproperties, the actual data type of a default value
                 # depends on the defined type of the zProperty.
-                type_ = get_zproperty_type(obj.type_)
+                type_ = Property.get_property_type(obj.type_)
 
             yaml_param = self.represent_str(p_data.get('yaml_param'))
             try:
@@ -196,6 +184,11 @@ class Dumper(yaml.Dumper):
             node_value = self.represent_data(item_value)
             value.append((node_key, node_value))
         return yaml.MappingNode(u'tag:yaml.org,2002:map', value)
+
+    def represent_DateTime(self, data):
+        """represent DateTime object"""
+        dt = data.asdatetime()
+        return self.represent_data(dt)
 
     def represent_severity(self, data):
         """represent Severity"""
@@ -312,10 +305,12 @@ Dumper.add_representer(ProcessClassOrganizerSpecParams, Dumper.represent_spec)
 Dumper.add_representer(ProcessClassSpecParams, Dumper.represent_spec)
 Dumper.add_representer(ImpactTriggerSpecParams, Dumper.represent_spec)
 Dumper.add_representer(LinkProviderSpecParams, Dumper.represent_spec)
+Dumper.add_representer(date, SafeRepresenter.represent_date)
+Dumper.add_representer(datetime, SafeRepresenter.represent_datetime)
+Dumper.add_representer(DateTime, Dumper.represent_DateTime)
 # representers for custom types
 from ..base.types import Color, Severity, multiline
 Dumper.add_representer(Color, SafeRepresenter.represent_str)
 Dumper.add_representer(Severity, Dumper.represent_severity)
 Dumper.add_representer(multiline, Dumper.represent_multiline)
-
 

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassPropertySpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassPropertySpec.py
@@ -9,6 +9,7 @@
 from Products.Zuul.form import schema
 from Products.Zuul.utils import ZuulMessageFactory as _t
 from Products.Zuul.infos import ProxyProperty
+from ..base.types import Property
 from ..helpers.OrderAndValue import OrderAndValue
 from .Spec import Spec, MethodInfoProperty, EnumInfoProperty
 
@@ -103,9 +104,12 @@ class ClassPropertySpec(Spec):
         if zplog:
             self.LOG = zplog
         self.class_spec = class_spec
-        self.name = name
-        self.default = default
-        self.type_ = type_
+
+        self._property = Property(name, type_, default)
+        self.name = self._property.name
+        self.default = self._property.default
+        self.type_ = self._property.type_
+
         self.label = label or self.name
         self.short_label = short_label or self.label
         self.index_type = index_type

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ZPropertySpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ZPropertySpec.py
@@ -7,6 +7,7 @@
 #
 ##############################################################################
 from Products.ZenRelations.zPropertyCategory import setzPropertyCategory
+from ..base.types import Property
 from .Spec import Spec
 
 
@@ -45,21 +46,15 @@ class ZPropertySpec(Spec):
             self.LOG = zplog
 
         self.zenpack_spec = zenpack_spec
-        self.name = name
-        self.type_ = type_
+
+        self._property = Property(name, type_, default)
+        self.name = self._property.name
+        self.type_ = self._property.type_
+        self.default = self._property.default
+
         self.category = category
         self.label = label or name
         self.description = description
-
-        if default is None:
-            self.default = {
-                'string': '',
-                'password': '',
-                'lines': [],
-                'boolean': False,
-            }.get(self.type_, None)
-        else:
-            self.default = default
 
     def create(self):
         """Implement specification."""

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_zprop_types.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_zprop_types.py
@@ -11,18 +11,19 @@
 """
     Ensure that zproperty types are respected
 """
+from types import NoneType
 from ZenPacks.zenoss.ZenPackLib.tests import ZPLBaseTestCase
-
+from DateTime import DateTime
 
 YAML_DOC = """
-name: ZenPacks.zenoss.ZPropertyTest
+name: ZenPacks.zenoss.PropertyTest
 zProperties:
-
   zStringProperty:
     type: string
-    default: ''
+    default: 'TEST'
   zPasswordProperty:
     type: password
+    default: TEST
   zBooleanProperty:
     default: false
     type: boolean
@@ -35,44 +36,114 @@ zProperties:
   zLinesProperty:
     type: lines
     default: ['this','that']
+  zLongProperty:
+    type: long
+    default: 10000000
+  zStringPropertyUnset:
+    type: string
+  zPasswordPropertyUnset:
+    type: password
+  zBooleanPropertyUnset:
+    type: boolean
+  zIntPropertyUnset:
+    type: int
+  zFloatPropertyUnset:
+    type: float
+  zLinesPropertyUnset:
+    type: lines
+  zLongPropertyUnset:
+    type: long
+classes:
+  BasicDevice:
+    base: [zenpacklib.Device]
+    properties:
+      dateTimeProperty:
+        type: date
+        default: 1975/08/21 00:00:00 UTC
+      stringProperty:
+        type: string
+        default: ''
+      passwordProperty:
+        type: password
+      booleanProperty:
+        default: true
+        type: boolean
+      intProperty:
+        default: 1
+        type: int
+      floatProperty:
+        default: 1.0
+        type: float
+      longProperty:
+        default: 0
+        type: long
+      linesProperty:
+        type: lines
+        default: ['this','that']
 """
 
 
-class TestZenProperties(ZPLBaseTestCase):
+class TestPropertyTypes(ZPLBaseTestCase):
     """
-    Ensure that zproperty types are respected
+    Ensure that _properties/zProperties types are respected
     """
     yaml_doc = YAML_DOC
+    disableLogging = False
 
     def test_zProperties(self):
-        config = self.configs.get('ZenPacks.zenoss.ZPropertyTest')
+        config = self.configs.get('ZenPacks.zenoss.PropertyTest')
         cfg = config.get('cfg')
         zprops = cfg.zProperties
-        self.is_valid(zprops.get('zStringProperty'), str, '')
-        self.is_valid(zprops.get('zPasswordProperty'), str, '')
-        self.is_valid(zprops.get('zBooleanProperty'), bool, False)
-        self.is_valid(zprops.get('zIntProperty'), int, 1)
-        self.is_valid(zprops.get('zFloatProperty'), float, 1.0)
-        self.is_valid(zprops.get('zLinesProperty'), list, ['this', 'that'])
+        self.is_valid(zprops.get('zStringProperty'), str, 'TEST', 'zProperty')
+        self.is_valid(zprops.get('zPasswordProperty'), str, 'TEST', 'zProperty')
+        self.is_valid(zprops.get('zBooleanProperty'), bool, False, 'zProperty')
+        self.is_valid(zprops.get('zIntProperty'), int, 1, 'zProperty')
+        self.is_valid(zprops.get('zFloatProperty'), float, 1.0, 'zProperty')
+        self.is_valid(zprops.get('zLinesProperty'), list, ['this', 'that'], 'zProperty')
+        self.is_valid(zprops.get('zLongProperty'), long, 10000000, 'zProperty')
 
-    def is_valid(self, spec, target_type, target_value):
-        ''''''
+        self.is_valid(zprops.get('zStringPropertyUnset'), str, '', 'zProperty')
+        self.is_valid(zprops.get('zPasswordPropertyUnset'), str, '', 'zProperty')
+        self.is_valid(zprops.get('zBooleanPropertyUnset'), bool, False, 'zProperty')
+        self.is_valid(zprops.get('zIntPropertyUnset'), NoneType, None, 'zProperty')
+        self.is_valid(zprops.get('zFloatPropertyUnset'), NoneType, None, 'zProperty')
+        self.is_valid(zprops.get('zLinesPropertyUnset'), list, [], 'zProperty')
+        self.is_valid(zprops.get('zLongPropertyUnset'), NoneType, None, 'zProperty')
+
+    def test_properties(self):
+        config = self.configs.get('ZenPacks.zenoss.PropertyTest')
+        cfg = config.get('cfg')
+        spec = cfg.classes.get('BasicDevice')
+        props = spec.properties
+        self.is_valid(props.get('dateTimeProperty'), DateTime, DateTime('1975/08/21 00:00:00 UTC'), '_property')
+        self.is_valid(props.get('stringProperty'), str, '', '_property')
+        self.is_valid(props.get('passwordProperty'), str, '', '_property')
+        self.is_valid(props.get('booleanProperty'), bool, True, '_property')
+        self.is_valid(props.get('intProperty'), int, 1, '_property')
+        self.is_valid(props.get('floatProperty'), float, 1.0, '_property')
+        self.is_valid(props.get('linesProperty'), list, ['this', 'that'], '_property')
+        self.is_valid(props.get('longProperty'), long, 0, '_property')
+
+    def is_valid(self, spec, target_type, target_value, p_type):
+        """Validate property type and default value"""
+        # verify property type
         self.assertTrue(isinstance(spec.default, target_type),
-                'zProperty ({}) should be {}, got {}'.format(spec.name,
-                                                                      target_type.__name__,
-                                                                      type(spec.default).__name__))
+            '{} ({}) should be {}, got {}'.format(
+            p_type, spec.name, target_type.__name__, type(spec.default).__name__))
+
+        # verify default value
         self.assertEquals(spec.default, target_value,
-                'zProperty ({}) should be {}, got {}'.format(spec.name,
-                                                            target_value,
-                                                            spec.default))
+            '{} ({}) should be {}, got {}'.format(
+            p_type, spec.name, target_value, spec.default))
 
 
 def test_suite():
     """Return test suite for this module."""
     from unittest import TestSuite, makeSuite
     suite = TestSuite()
-    suite.addTest(makeSuite(TestZenProperties))
+    suite.addTest(makeSuite(TestPropertyTypes))
     return suite
+
 
 if __name__ == "__main__":
     from zope.testrunner.runner import Runner


### PR DESCRIPTION
- Partially addresses ZPS-1725, ZPS-481
- In addition to validating for quality control, changes can be
leveraged for improved change auditing as well as for expanded data type
support
- Added Property class to handle input validation and defaults for
supported ClassProperty/ZProperty values
- Updated ClassPropertySpec and ZPropertySpec to perform input
validation
- Added support for DateTime class, including constructor/representers
for YAML Dumper/Loader classes
- Renamed unit test test_zprop_types.py to test_property_types.py
- Expanded unit test to cover both specified and default property
types/values, and testing both ZPropertySpec and ClassPropertySpec
examples