### PR TITLE
Refactor/simplify Organizer-related Specs (ZPS-3190, ZPS-3189, ZPS-810)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
@@ -79,11 +79,11 @@ class ZenPack(ZenPackBase):
 
         # Load event classes
         for ecname, ecspec in self.event_classes.iteritems():
-            ecspec.instantiate(app.zport.dmd)
+            ec_org = ecspec.create_organizer(app.zport.dmd)
 
         # Create Process Classes
         for psname, psspec in self.process_class_organizers.iteritems():
-            psspec.create(app.zport.dmd)
+            ps_org = psspec.create_organizer(app.zport.dmd)
 
     def remove(self, app, leaveObjects=False):
         if self._v_specparams is None:
@@ -152,19 +152,14 @@ class ZenPack(ZenPackBase):
                 self._buildDeviceRelations(app)
 
             for dcname, dcspec in self.device_classes.iteritems():
-                if dcspec.remove:
-                    self.remove_device_class(app, dcspec)
+                dcspec.remove_organizer(app.zport.dmd, self)
 
-            # Remove EventClasses with remove flag set
-            self.remove_organizer_or_subs(app.zport.dmd.Events,
-                                          self.event_classes,
-                                          'mappings',
-                                          'removeInstances')
-            # Remove Process Classes/Organizers with remove flag set
-            self.remove_organizer_or_subs(app.zport.dmd.Processes,
-                                          self.process_class_organizers,
-                                          'process_classes',
-                                          'removeOSProcessClasses')
+            for ecname, ecspec in self.event_classes.iteritems():
+                ecspec.remove_organizer(app.zport.dmd, self)
+
+            for pcname, pcspec in self.process_class_organizers.iteritems():
+                pcspec.remove_organizer_or_subs(
+                    app.zport.dmd, 'process_classes', 'removeOSProcessClasses', self)
 
         super(ZenPack, self).remove(app, leaveObjects=leaveObjects)
 
@@ -258,49 +253,6 @@ class ZenPack(ZenPackBase):
         if source_object:
             self.rename_object(parent, relname, source_id, dest_id)
 
-    def remove_organizer_or_subs(self, dmd_root, classes, sub_class, remove_name):
-        '''Remove the organizer or subclasses within an organizer
-        Used for event classes, process classes, windows services
-        The specs should use path to describe the organizer name/path
-        For subclasses, use klass_string for the class type name
-        Also be sure to set zpl_managed in the specs
-        '''
-        for cname, cspec in classes.iteritems():
-            organizerPath = cspec.path
-            try:
-                organizer = dmd_root.getOrganizer(organizerPath)
-            except KeyError:
-                self.LOG.warning('Unable to find {} {}'.format(dmd_root.__class__.__name__, cspec.path))
-                continue
-
-            # Anything left in packables will be removed the platform.
-            try:
-                self.packables.removeRelation(organizer)
-            except Exception:
-                # The organizer wasn't in packables.
-                pass
-
-            if cspec.remove and hasattr(organizer, 'zpl_managed') and organizer.zpl_managed:
-                # make sure the organizer is zpl_managed before we try and delete it
-                # also double-check that we do not remove anything important like /Status or Processes
-                if organizerPath in RESERVED_CLASSES:
-                    continue
-                self.LOG.info('Removing {} {}'.format(organizer.__class__.__name__, cspec.path))
-                dmd_root.manage_deleteOrganizer(organizer.getDmdKey())
-            else:
-                sub_classes = getattr(cspec, sub_class, {})
-                remove_func = getattr(organizer, remove_name, None)
-                if not remove_func:
-                    continue
-                for subclass_id, subclass_spec in sub_classes.items():
-                    if subclass_spec.remove:
-                        preppedId = organizer.prepId(subclass_id)
-                        # make sure object is zpl managed
-                        obj = organizer.findObject(preppedId)
-                        if getattr(obj, 'zpl_managed', False):
-                            self.LOG.info('Removing {} {} @ {}'.format(subclass_spec.klass_string, subclass_id, cspec.path))
-                            remove_func(preppedId)
-
     def object_changed(self, app, object, spec, specparam):
         """Compare new and old objects with prototype creation"""
         # get YAML representation of object
@@ -334,103 +286,19 @@ class ZenPack(ZenPackBase):
             return ''.join(difflib.unified_diff(lines_existing, lines_new))
         return None
 
-    def set_zproperties(self, app, dc, dcspec):
-        """Set zProperties given by spec"""
-        for zprop, value in dcspec.zProperties.iteritems():
-            if dc.getPropertyType(zprop) is None:
-                self.LOG.error(
-                    "Unable to set zProperty %s on %s (undefined zProperty)",
-                    zprop, dcspec.path)
-            else:
-                self.LOG.debug(
-                    "Setting zProperty %s to %r on %s (was %r)",
-                    zprop, value, dcspec.path, getattr(dc, zprop, ''))
-
-                # We want to explicitly set the value even if it's the same as
-                # what's being acquired. This is why aq_base is required.
-                aq_base(dc).setZenProperty(zprop, value)
-
     def create_device_classes(self, app):
-        """Create device classes. Set their zProperties and devtypes."""
-        for dcname in sorted(self.device_classes):
-            # Device classes must be created in alphanumeric order to
-            # prevent children from implicitly creating their parents. When
-            # children implicitly create their parents, zProperty values
-            # won't get set on the parents.
-            dcspec = self.device_classes[dcname]
-
-            if dcspec.create:
-                self.create_device_class(app, dcspec)
-            else:
-                device_class = dcspec.get_organizer(app.zport.dmd)
-                if not device_class:
-                    self.LOG.warn(
-                        "Device Class (%s) not found",
-                        dcspec.path)
-                    continue
-
-                # Optionally set zProperties if reset is True
-                if dcspec.reset:
-                    self.LOG.info('Resetting zProperties on {}'.format(device_class.getDmdKey()))
-                    self.set_zproperties(app, device_class, dcspec)
-
-    def create_device_class(self, app, dcspec):
-        """Create and return a DeviceClass. Set zProperties and devtypes.
-
-        zProperties and devtypes will only be set if the device class
-        doesn't already exist. This is done to prevent overwriting of user
-        customizations on upgrade.
-
         """
-        dcObject = dcspec.get_organizer(app.zport.dmd)
-        if dcObject:
-            self.LOG.debug(
-                "Existing %s device class - not overwriting properties",
-                dcspec.path)
-
-            return dcObject
-
-        self.LOG.debug("Creating %s device class", dcspec.path)
-        dcObject = app.zport.dmd.Devices.createOrganizer(dcspec.path)
-
-        # Set zProperties.
-        self.set_zproperties(app, dcObject, dcspec)
-
-        # Register devtype.
-        if dcObject and dcspec.description and dcspec.protocol:
-            self.LOG.debug(
-                "Registering devtype for %s: %s (%s)",
-                dcspec.path,
-                dcspec.protocol,
-                dcspec.description)
-
-            try:
-                # We want to explicitly set the value even if it's the same as
-                # what's being acquired. This is why aq_base is required.
-                aq_base(dcObject).register_devtype(
-                    dcspec.description,
-                    dcspec.protocol)
-            except Exception as e:
-                self.LOG.warn(
-                    "Error registering devtype for %s: %s (%s)",
-                    dcspec.path,
-                    dcspec.protocol,
-                    e)
-
-        return dcObject
-
-    def remove_device_class(self, app, dcspec):
-        """Remove a DeviceClass"""
-        path = [p for p in dcspec.path.lstrip('/').split('/') if p != 'Devices']
-        organizerPath = '/{}'.format('/'.join(['Devices'] + path))
-        try:
-            app.zport.dmd.Devices.getOrganizer(organizerPath)
-            try:
-                app.zport.dmd.Devices.manage_deleteOrganizer(organizerPath)
-            except Exception as e:
-                self.LOG.error('Unable to remove DeviceClass {} ({})'.format(dcspec.path, e))
-        except KeyError:
-            self.LOG.warning('Unable to remove DeviceClass {} (not found)'.format(dcspec.path))
+        Device classes must be created in alphanumeric order to
+        prevent children from implicitly creating their parents. When
+        children implicitly create their parents, zProperty values
+        won't get set on the parents.
+        """
+        for dcname in sorted(self.device_classes):
+            dcspec = self.device_classes[dcname]
+            device_class = dcspec.create_organizer(app.zport.dmd)
+            if not device_class:
+                self.LOG.warn("Device Class (%s) not found", dcspec.path)
+                continue
 
     def manage_exportPack(self, download="no", REQUEST=None):
         """Export ZenPack to $ZENHOME/export directory.

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/DeviceClassSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/DeviceClassSpecParams.py
@@ -13,8 +13,8 @@ from ..spec.DeviceClassSpec import DeviceClassSpec
 
 
 class DeviceClassSpecParams(OrganizerSpecParams, DeviceClassSpec):
+
     def __init__(self, zenpack_spec, path, zProperties=None, templates=None, **kwargs):
-        OrganizerSpecParams.__init__(self, zenpack_spec, path, **kwargs)
-        self.zProperties = zProperties
+        OrganizerSpecParams.__init__(self, zenpack_spec, path, zProperties, **kwargs)
         self.templates = self.specs_from_param(
             RRDTemplateSpecParams, 'templates', templates, zplog=self.LOG)

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/EventClassSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/EventClassSpecParams.py
@@ -13,8 +13,9 @@ from ..spec.EventClassSpec import EventClassSpec
 
 
 class EventClassSpecParams(OrganizerSpecParams, EventClassSpec):
-    def __init__(self, zenpack_spec, path, description='', transform='', mappings=None, **kwargs):
-        OrganizerSpecParams.__init__(self, zenpack_spec, path, **kwargs)
+
+    def __init__(self, zenpack_spec, path, description='', transform='', zProperties=None, mappings=None, **kwargs):
+        OrganizerSpecParams.__init__(self, zenpack_spec, path, zProperties, **kwargs)
         self.description = description
         self.transform = multiline(transform)
         self.mappings = self.specs_from_param(

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/OrganizerSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/OrganizerSpecParams.py
@@ -11,7 +11,9 @@ from ..spec.OrganizerSpec import OrganizerSpec
 
 
 class OrganizerSpecParams(SpecParams, OrganizerSpec):
-    def __init__(self, zenpack_spec=None, path='', **kwargs):
+
+    def __init__(self, zenpack_spec=None, path='', zProperties=None, **kwargs):
         SpecParams.__init__(self, **kwargs)
         self.zenpack_spec = zenpack_spec
         self.path = path.lstrip("/")
+        self.zProperties = zProperties

--- a/ZenPacks/zenoss/ZenPackLib/lib/params/ProcessClassOrganizerSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/ProcessClassOrganizerSpecParams.py
@@ -13,8 +13,9 @@ from ..spec.ProcessClassOrganizerSpec import ProcessClassOrganizerSpec
 
 
 class ProcessClassOrganizerSpecParams(OrganizerSpecParams, ProcessClassOrganizerSpec):
-    def __init__(self, zenpack_spec, path, description='', process_classes=None, remove=False, **kwargs):
-        OrganizerSpecParams.__init__(self, zenpack_spec, path, **kwargs)
+
+    def __init__(self, zenpack_spec, path, description='', zProperties=None, process_classes=None, remove=False, **kwargs):
+        OrganizerSpecParams.__init__(self, zenpack_spec, path, zProperties, **kwargs)
         self.description = description
         self.remove = remove
         self.process_classes = self.specs_from_param(

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/DeviceClassSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/DeviceClassSpec.py
@@ -6,6 +6,7 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
+from Acquisition import aq_base
 from .OrganizerSpec import OrganizerSpec
 from .RRDTemplateSpec import RRDTemplateSpec
 
@@ -17,51 +18,47 @@ class DeviceClassSpec(OrganizerSpec):
             self,
             zenpack_spec,
             path,
-            create=True,
-            zProperties=None,
-            remove=False,
-            templates=None,
             description=None,
-            protocol=None,
+            zProperties=None,
+            create=True,
+            remove=False,
             reset=False,
+            protocol=None,
+            templates=None,
             _source_location=None,
             zplog=None):
         """
             Create a DeviceClass Specification
 
+            :param description: Description used for registering devtype
+            :type description: str
+            :param zProperties: zProperty values to set upon this DeviceClass
+            :type zProperties: dict(str)
             :param create: Create the DeviceClass with ZenPack installation, if it does not exist?
             :type create: bool
             :param remove: Remove the DeviceClass when ZenPack is removed?
             :type remove: bool
-            :param zProperties: zProperty values to set upon this DeviceClass
-            :type zProperties: dict(str)
-            :param templates: TODO
-            :type templates: SpecsParameter(RRDTemplateSpec)
-            :param description: Description used for registering devtype
-            :type description: str
-            :param protocol: Protocol to use for registered devtype
-            :type protocol: str
             :param reset:  If True, reset any zProperties that differ from given
             :type reset: bool
+            :param protocol: Protocol to use for registered devtype
+            :type protocol: str
+            :param templates: TODO
+            :type templates: SpecsParameter(RRDTemplateSpec)
         """
         super(DeviceClassSpec, self).__init__(
             zenpack_spec,
             path,
+            description,
+            zProperties,
+            create,
+            remove,
+            reset,
             _source_location=_source_location)
 
         if zplog:
             self.LOG = zplog
 
-        self.create = bool(create)
-        self.remove = bool(remove)
-        self.description = description
         self.protocol = protocol
-        self.reset = reset
-
-        if zProperties is None:
-            self.zProperties = {}
-        else:
-            self.zProperties = zProperties
 
         self.templates = self.specs_from_param(
             RRDTemplateSpec, 'templates', templates, zplog=self.LOG)
@@ -69,3 +66,32 @@ class DeviceClassSpec(OrganizerSpec):
     def get_root(self, dmd):
         """Return the root object for this organizer."""
         return dmd.Devices
+
+    def create_organizer(self, dmd):
+        """Return existing or new device class organizer"""
+        dc_org = super(DeviceClassSpec, self).create_organizer(dmd)
+        if not dc_org:
+            return
+        self.register_devtype(dc_org)
+        return dc_org
+
+    def register_devtype(self, dc_org):
+        """Register devtype for device class organizer"""
+        if self.description and self.protocol:
+            self.LOG.debug(
+                "Registering devtype for %s: %s (%s)",
+                self.path,
+                self.protocol,
+                self.description)
+            try:
+                # We want to explicitly set the value even if it's the same as
+                # what's being acquired. This is why aq_base is required.
+                aq_base(dc_org).register_devtype(
+                    self.description,
+                    self.protocol)
+            except Exception as e:
+                self.LOG.warn(
+                    "Error registering devtype for %s: %s (%s)",
+                    self.path,
+                    self.protocol,
+                    e)

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/EventClassSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/EventClassSpec.py
@@ -13,64 +13,90 @@ from .EventClassMappingSpec import EventClassMappingSpec
 
 class EventClassSpec(OrganizerSpec):
     """Initialize a EventClass via Python at install time."""
+
     def __init__(
             self,
             zenpack_spec,
             path,
             description='',
-            transform='',
+            zProperties=None,
+            create=True,
             remove=False,
+            reset=True,
+            transform='',
             mappings=None,
             _source_location=None,
             zplog=None):
         """
-          :param remove: Remove the EventClass when ZenPack is removed?
-          :type remove: bool
-          :param description: Description of the EventClass
-          :type description: str
-          :param transform: EventClass Transformation
-          :type transform: multiline
-          :param mappings: TODO
-          :type mappings: SpecsParameter(EventClassMappingSpec)
+            Create an Event Class Organizer Specification
+            
+            :param description: Description of Event Class Organizer
+            :type description: str
+            :param zProperties: zProperty values to set upon this Organizer
+            :type zProperties: dict(str)
+            :param create: Create the Event Class Organizer with ZenPack installation, if it does not exist?
+            :type create: bool
+            :param remove: Remove the Event Class Organizer when ZenPack is removed?
+            :type remove: bool
+            :param reset:  If True, reset any zProperties that differ from given
+            :type reset: bool
+            :param transform: EventClass Transformation
+            :type transform: multiline
+            :param mappings: TODO
+            :type mappings: SpecsParameter(EventClassMappingSpec)
         """
         super(EventClassSpec, self).__init__(
             zenpack_spec,
             path,
+            description,
+            zProperties,
+            create,
+            remove,
+            reset,
             _source_location=_source_location)
 
         if zplog:
             self.LOG = zplog
 
-        self.description = description
         self.transform = multiline(transform)
-        self.remove = bool(remove)
+
         self.mappings = self.specs_from_param(
             EventClassMappingSpec, 'mappings', mappings, zplog=self.LOG)
 
-    def instantiate(self, dmd):
-        ecObject = self.get_organizer(dmd)
-        if not ecObject:
-            ecObject = dmd.Events.createOrganizer(self.path)
-            ecObject.zpl_managed = True
+    def create_organizer(self, dmd):
+        """Return existing or new event class organizer"""
+        ec_org = super(EventClassSpec, self).create_organizer(dmd)
+        if not ec_org:
+            return
 
-        if self.description != '':
-            if not ecObject.description == self.description:
-                self.LOG.debug('Description of Event Class {} has changed from'
-                               ' {} to {}'.format(self.path,
-                                                  ecObject.description,
-                                                  self.description))
-                ecObject.description = self.description
-        if self.transform != '':
-            if not ecObject.transform == self.transform:
-                self.LOG.debug('Transform for Event Class {} has changed from'
-                               '\n{}\n to \n{}'.format(self.path,
-                                                       ecObject.transform,
-                                                       self.transform))
-                ecObject.transform = self.transform
+        if self.description != '' and self.description != ec_org.description:
+            self.LOG.debug('Description of Event Class {} has changed from'
+                ' {} to {}'.format(self.path,
+                ec_org.description, self.description))
+
+            ec_org.ec_org = self.description
+
+        if self.transform != '' and self.transform != ec_org.transform:
+            self.LOG.debug(
+                'Transform for Event Class {} has changed from'
+                '\n{}\n to \n{}'.format(self.path,
+                ec_org.transform, self.transform))
+
+            ec_org.transform = self.transform
 
         for mapping_id, mapping_spec in self.mappings.items():
-            mapping_spec.create(ecObject)
+            mapping_spec.create(ec_org)
+
+        return ec_org
 
     def get_root(self, dmd):
         """Return the root object for this organizer."""
         return dmd.Events
+
+    def remove_organizer(self, dmd, zenpack=None):
+        """Remove the organizer or subclasses within an organizer
+        """
+        org_removed = super(EventClassSpec, self).remove_organizer(dmd, zenpack)
+        if not org_removed:
+            self.remove_subs(dmd, 'mappings', 'removeInstances')
+        return org_removed

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/OrganizerSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/OrganizerSpec.py
@@ -6,8 +6,14 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
-
+from Acquisition import aq_base
 from .Spec import Spec
+from posix import remove
+
+RESERVED_CLASSES = set(['Status', 'App', 'Cmd', 'Perf',
+                        'Heartbeat', 'Unknown', 'Change', 'Processes',
+                        'Services', 'WinService', 'IpService',
+                        'Devices', 'Server'])
 
 
 class OrganizerSpec(Spec):
@@ -21,7 +27,17 @@ class OrganizerSpec(Spec):
 
     """
 
-    def __init__(self, zenpack_spec, path, _source_location=None, zplog=None):
+    def __init__(
+            self,
+            zenpack_spec,
+            path,
+            description='',
+            zProperties=None,
+            create=True,
+            remove=False,
+            reset=True,
+            _source_location=None,
+            zplog=None):
         """Create an Organizer specification."""
         super(OrganizerSpec, self).__init__(_source_location=_source_location)
 
@@ -30,6 +46,16 @@ class OrganizerSpec(Spec):
 
         self.zenpack_spec = zenpack_spec
         self.path = path.lstrip("/")
+        self.description = description
+
+        if zProperties is None:
+            self.zProperties = {}
+        else:
+            self.zProperties = zProperties
+
+        self.create = bool(create)
+        self.remove = bool(remove)
+        self.reset = bool(reset)
 
     def get_root(self, dmd):
         """Return the root for this organizer.
@@ -50,3 +76,94 @@ class OrganizerSpec(Spec):
             # Guard against acquisition returning us the wrong organizer.
             if organizer.getOrganizerName().lstrip("/") == self.path:
                 return organizer
+
+    def create_organizer(self, dmd):
+        """Return organizer whether existing or new"""
+        org_obj = self.get_organizer(dmd)
+
+        if org_obj:
+            if self.reset:
+                self.set_zproperties(dmd)
+        else:
+            if self.create:
+                org_obj = self.get_root(dmd).createOrganizer(self.path)
+                org_obj.zpl_managed = True
+                self.set_zproperties(dmd)
+
+        return org_obj
+
+    def set_zproperties(self, dmd):
+        """Set zProperties on a given Organizer according to the Spec"""
+        org_obj = self.get_organizer(dmd)
+        for zprop, value in self.zProperties.iteritems():
+            if org_obj.getPropertyType(zprop) is None and org_obj.getProperty(zprop) is None:
+                self.LOG.error(
+                    "Unable to set zProperty %s on %s (undefined zProperty)",
+                    zprop, self.path)
+            else:
+                self.LOG.debug(
+                    "Setting zProperty %s to %r on %s (was %r)",
+                    zprop, value, self.path, getattr(org_obj, zprop, ''))
+
+                # We want to explicitly set the value even if it's the same as
+                # what's being acquired. This is why aq_base is required.
+                aq_base(org_obj).setZenProperty(zprop, value)
+
+    def remove_organizer(self, dmd, zenpack=None):
+        # also double-check that we do not remove anything important like /Status or Processes
+        if self.path.lstrip('/') in RESERVED_CLASSES:
+            self.LOG.debug("Not removing reserved organizer %s", self.path)
+            return False
+
+        org_obj = self.get_organizer(dmd)
+        if not org_obj:
+            self.LOG.info("Not removing nonexistent organzier %s", self.path)
+            return False
+
+        if zenpack:
+            # Anything left in packables will be removed the platform.
+            try:
+                zenpack.packables.removeRelation(organizer)
+            except Exception:
+                # The organizer wasn't in packables.
+                pass
+
+        # make sure the organizer is zpl_managed before we try and delete it
+        if self.remove and getattr(org_obj, 'zpl_managed', False):
+            self.get_root(dmd).manage_deleteOrganizer(org_obj.getDmdKey())
+            self.LOG.info('Removing {} {}'.format(org_obj.__class__.__name__, self.path))
+            return True
+
+    def remove_subs(self, dmd, map_name, remove_name):
+        """Remove subclasses within an organizer
+        Used for event classes, process classes, windows services
+        The specs should use path to describe the organizer name/path
+        For subclasses, use klass_string for the class type name
+        Also be sure to set zpl_managed in the specs
+        """
+        org_obj = self.get_organizer(dmd)
+        if not org_obj:
+            return
+
+        remove_func = getattr(org_obj, remove_name, None)
+        if not remove_func:
+            return
+
+        for name, spec in getattr(self, map_name, {}).items():
+            if not spec.remove:
+                continue
+
+            preppedId = org_obj.prepId(name)
+            # make sure object is zpl managed
+            obj = org_obj.findObject(preppedId)
+
+            if getattr(obj, 'zpl_managed', False):
+                self.LOG.info('Removing {} {} @ {}'.format(spec.klass_string, name, self.path))
+                remove_func(preppedId)
+
+    def remove_organizer_or_subs(self, dmd, map_name, remove_name, zenpack=None):
+        """Remove the organizer or subclasses within an organizer
+        """
+        org_removed = self.remove_organizer(dmd, zenpack)
+        if not org_removed:
+            self.remove_subs(dmd, map_name, remove_name)

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ProcessClassOrganizerSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ProcessClassOrganizerSpec.py
@@ -13,48 +13,72 @@ from .ProcessClassSpec import ProcessClassSpec
 
 class ProcessClassOrganizerSpec(OrganizerSpec):
     """Initialize a Process Set via Python at install time."""
+
     def __init__(
             self,
             zenpack_spec,
             path,
             description='',
+            zProperties=None,
+            create=True,
             remove=False,
+            reset=True,
             process_classes=None,
             _source_location=None,
             zplog=None):
         """
-          :param description: Description of Process Class Organizer
-          :type description: str
-          :param process_classes: Process Class specs
-          :type process_classes: SpecsParameter(ProcessClassSpec)
-          :param remove: Remove Organizer on ZenPack removal
-          :type remove: boolean
+            Create a Process Class Organizer Specification
+            
+            :param description: Description of Process Class Organizer
+            :type description: str
+            :param zProperties: zProperty values to set upon this Organizer
+            :type zProperties: dict(str)
+            :param create: Create the Process Class Organizer with ZenPack installation, if it does not exist?
+            :type create: bool
+            :param remove: Remove the Process Class Organizer when ZenPack is removed?
+            :type remove: bool
+            :param reset:  If True, reset any zProperties that differ from given
+            :type reset: bool
+            :param process_classes: Process Class specs
+            :type process_classes: SpecsParameter(ProcessClassSpec)
         """
         super(ProcessClassOrganizerSpec, self).__init__(
             zenpack_spec,
             path,
+            description,
+            zProperties,
+            create,
+            remove,
+            reset,
             _source_location=_source_location)
 
         if zplog:
             self.LOG = zplog
 
-        self.description = description
-        self.remove = remove
         self.process_classes = self.specs_from_param(
             ProcessClassSpec, 'process_classes', process_classes, zplog=self.LOG)
 
-    def create(self, dmd):
-        porg = self.get_organizer(dmd)
-        if not porg:
-            porg = dmd.Processes.createOrganizer(self.path)
-            porg.zpl_managed = True
+    def create_organizer(self, dmd):
+        """Return existing or new process class organizer"""
+        ps_org = super(ProcessClassOrganizerSpec, self).create_organizer(dmd)
+        if not ps_org:
+            return
 
-        if porg.description != self.description:
-            porg.description = self.description
+        if self.description != '' and self.description != ps_org.description:
+            ps_org.description = self.description
 
         for process_class_id, process_class_spec in self.process_classes.items():
-            process_class_spec.create(dmd, porg)
+            process_class_spec.create(dmd, ps_org)
+        return ps_org
 
     def get_root(self, dmd):
         """Return the root object for this organizer."""
         return dmd.Processes
+
+    def remove_organizer(self, dmd, zenpack=None):
+        """Remove the organizer or subclasses within an organizer
+        """
+        org_removed = super(ProcessClassOrganizerSpec, self).remove_organizer(dmd, zenpack)
+        if not org_removed:
+            self.remove_subs(dmd, 'process_classes', 'removeOSProcessClasses')
+        return org_removed

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_device_class_existing_zproperties.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_device_class_existing_zproperties.py
@@ -41,7 +41,8 @@ class TestZPropertyReset(ZPLBaseTestCase):
 
         # create the device class
         for dcname, dcspec in cfg.device_classes.items():
-            zenpack.create_device_class(self.app, dcspec)
+            dcspec.create_organizer(self.dmd)
+            # zenpack.create_device_class(self.app, dcspec)
             # verify that it was created
             dc = self.device_class_exists(dcspec.path)
             self.assertTrue(dc,
@@ -49,7 +50,7 @@ class TestZPropertyReset(ZPLBaseTestCase):
 
         for dcname, dcspec in cfg.device_classes.iteritems():
             if dcspec.reset:
-                zenpack.set_zproperties(self.app, dc, dcspec)
+                dcspec.set_zproperties(self.dmd)
             self.assertFalse(getattr(dc, 'zSnmpMonitorIgnore'),
                 'Device class {} zProperty was not set correctly'.format(dcspec.path))
 

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_device_class_removal.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_device_class_removal.py
@@ -14,7 +14,6 @@
 """
 from ZenPacks.zenoss.ZenPackLib.tests import ZPLBaseTestCase
 
-
 YAML_DOC = """
 name: ZenPacks.zenoss.DeviceClasses
 
@@ -37,18 +36,17 @@ class TestDeviceClassRemoval(ZPLBaseTestCase):
     def test_device_class(self):
         config = self.configs.get('ZenPacks.zenoss.DeviceClasses')
         cfg = config.get('cfg')
-        zenpack = cfg._zenpack_class(self.app)
 
         # create the device class
         for dcname, dcspec in cfg.device_classes.items():
-            zenpack.create_device_class(self.app, dcspec)
+            dcspec.create_organizer(self.dmd)
             # verify that it was created
             self.assertTrue(self.device_class_exists(dcspec.path),
                             'Device class {} was not created'.format(dcspec.path))
 
         for dcname, dcspec in cfg.device_classes.iteritems():
             if dcspec.remove:
-                zenpack.remove_device_class(self.app, dcspec)
+                dcspec.remove_organizer(self.dmd)
                 # verify that it was removed
                 self.assertFalse(self.device_class_exists(dcspec.path),
                                 'Device class {} was not removed'.format(dcspec.path))
@@ -67,6 +65,7 @@ def test_suite():
     suite = TestSuite()
     suite.addTest(makeSuite(TestDeviceClassRemoval))
     return suite
+
 
 if __name__ == "__main__":
     from zope.testrunner.runner import Runner

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_organizer_specs.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_organizer_specs.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python
+
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2018, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+"""
+    Test that device classes can optionally have their zProperties reset (ZPS-810)
+"""
+
+from ZenPacks.zenoss.ZenPackLib.tests import ZPLBaseTestCase
+
+YAML_DOC = """
+name: ZenPacks.zenoss.Organizers
+
+device_classes:
+  /Server:
+    description: Basic Server Organizer
+    zProperties:
+      zSnmpMonitorIgnore: true
+    create: true
+    reset: true
+    remove: true
+  /Server/NewDevices:
+    description: Basic Server Organizer
+    zProperties:
+      zSnmpMonitorIgnore: true
+    create: true
+    reset: true
+    remove: true
+
+event_classes:
+  /Organizer/Mappings:
+    description: Basic Event Organizer with Mappings
+    create: true
+    reset: true
+    remove: false
+    mappings:
+      TestRemove:
+        eventClassKey: TestRemove
+        remove: true
+      TestRemain:
+        eventClassKey: TestRemain
+        remove: false
+  /Organizer/Status:
+    description: Basic Event Organizer
+    zProperties:
+      zFlappingThreshold: 6
+    create: true
+    reset: true
+    remove: true
+  /Status:
+    description: Basic Event Organizer
+    zProperties:
+      zFlappingThreshold: 6
+    create: true
+    reset: true
+    remove: true
+
+process_class_organizers:
+  /Test:
+    description: Basic Process Organizer
+    zProperties:
+      zAlertOnRestart: false
+    create: true
+    reset: true
+    remove: true
+  /TestClasses:
+    description: Basic Process Organizer
+    zProperties:
+      zAlertOnRestart: false
+    create: true
+    reset: true
+    remove: false
+    process_classes:
+      remove:
+        description: Description of the foo Process Class
+        includeRegex: sbin\/foo
+        replaceRegex: ".*"
+        replacement: Foo Process Class
+        excludeRegex: \\b(vim|tail|grep|tar|cat|bash)\\b
+        remove: true
+      remain:
+        description: Description of the bar Process Class
+        includeRegex: sbin\/bar
+        excludeRegex: "\\b(vim|tail|grep|tar|cat|bash)\\b"
+        replaceRegex: .*
+        replacement: Bar Process Class
+        monitor: true
+        alert_on_restart: false
+        fail_severity: 3
+        modeler_lock: 0
+        send_event_when_blocked: true
+        remove: false
+"""
+
+
+class TestOrganizerSpecs(ZPLBaseTestCase):
+    """
+    Test that Organizers can use zProperties and other attributes
+    
+        - test org creation
+            - with create true and false
+        - test zproperty setting
+            - with reset true and false
+        - test org removal
+            - with remove tru and false
+        - test removal of mappings/processes
+    """
+
+    yaml_doc = YAML_DOC
+    build = False
+    disableLogging = False
+
+    def afterSetUp(self):
+        super(TestOrganizerSpecs, self).afterSetUp()
+        config = self.configs.get('ZenPacks.zenoss.Organizers')
+        self.cfg = config.get('cfg')
+
+    def test_process_classes(self):
+        """Test that process class mappings are removed (or not) as intended"""
+        spec = self.cfg.process_class_organizers.get('/TestClasses')
+        name = spec.__class__.__name__
+
+        # create the organizer and mappings
+        init_org = spec.create_organizer(self.dmd)
+        # import pdb ; pdb.set_trace()
+        # 2 mappings should exist
+        self.assertEquals(len(init_org.osProcessClasses()), 2,
+            '{} {} is missing process class mappings'.format(name, spec.path))
+
+        # remove it
+        spec.remove_organizer(self.dmd)
+        # organizer should still exist
+        org = spec.get_organizer(self.dmd)
+
+        # this mapping should remain
+        self.assertTrue(org.osProcessClasses.findObject('remain'),
+            '{} {} process class mapping should not have been removed'.format(
+            name, spec.path))
+
+        # this one should be removed
+        gone = None
+        try:
+            gone = org.osProcessClasses.findObject('remove')
+        except AttributeError:
+            pass
+        self.assertIsNone(gone,
+                '{} {} mapping should have been removed'.format(name, spec.path))
+
+        # one mapping should remain
+        self.assertEquals(len(org.osProcessClasses()), 1,
+            '{} {} should only have one mapping left'.format(name, spec.path))
+
+    def test_event_mappings(self):
+        """Test that event class mappings are removed (or not) as intended"""
+        spec = self.cfg.event_classes.get('/Organizer/Mappings')
+        name = spec.__class__.__name__
+
+        # create the organizer and mappings
+        init_org = spec.create_organizer(self.dmd)
+        # 2 mappings should exist
+        self.assertEquals(len(init_org.instances()), 2,
+            '{} {} is missing event class mappings'.format(name, spec.path))
+
+        # remove it
+        spec.remove_organizer(self.dmd)
+        # organizer should still exist
+        org = spec.get_organizer(self.dmd)
+
+        # this mapping should remain
+        self.assertTrue(org.instances.findObject('TestRemain'),
+            '{} {} event class mapping should not have been removed'.format(
+            name, spec.path))
+
+        # this one should be removed
+        gone = None
+        try:
+            gone = org.instances.findObject('TestRemove')
+        except AttributeError:
+            pass
+        self.assertIsNone(gone,
+                '{} {} mapping should have been removed'.format(name, spec.path))
+
+        # one mapping should remain
+        self.assertEquals(len(org.instances()), 1,
+            '{} {} should only have one mapping left'.format(name, spec.path))
+
+    def test_device_class(self):
+        """Test that device class is created and zProperties set"""
+        self.get_organizer_results(
+            self.cfg.device_classes.get('/Server/NewDevices'),
+            'zSnmpMonitorIgnore', False)
+
+    def test_device_class_reserved(self):
+        """Test that device class is created and zProperties set"""
+        self.get_organizer_results(
+            self.cfg.device_classes.get('/Server'),
+            'zSnmpMonitorIgnore', False, True)
+
+    def test_event_class(self):
+        """Test that event class is created and zProperties set"""
+        self.get_organizer_results(
+            self.cfg.event_classes.get('/Organizer/Status'),
+            'zFlappingThreshold', 5)
+
+    def test_event_class_reserved(self):
+        """Test that event class is created and zProperties set"""
+        self.get_organizer_results(
+            self.cfg.event_classes.get('/Status'),
+            'zFlappingThreshold', 5, True)
+
+    def test_process_class_organizers(self):
+        """Test that process class is created and zProperties set"""
+        self.get_organizer_results(
+            self.cfg.process_class_organizers.get('/Test'),
+            'zAlertOnRestart', True)
+
+    def get_organizer_results(self, spec, zproperty, new_val, reserved=False):
+        """Test that device class is created and zProperties set"""
+
+        name = spec.__class__.__name__
+
+        default_val = spec.zProperties.get(zproperty)
+
+        #  class should not be created if create is False
+        spec.create = False
+        org = spec.create_organizer(self.app.zport.dmd)
+        self.assertIsNone(org,
+            '{} {} should not have been created'.format(name, spec.path))
+
+        # it should be created if create is True
+        spec.create = True
+        org = spec.create_organizer(self.dmd)
+        self.assertTrue(org,
+            '{} {} should have been created'.format(name, spec.path))
+        self.assertEquals(getattr(org, zproperty), default_val,
+            '{} {} zProperty was not set correctly'.format(name, spec.path))
+
+        # Since reset is true, the zproperty should change
+        spec.zProperties[zproperty] = new_val
+        org = spec.create_organizer(self.dmd)
+        self.assertEquals(getattr(org, zproperty), new_val,
+            '{} {} zProperty was not set correctly'.format(name, spec.path))
+
+        # with reset false, zproperty should stay the same
+        spec.reset = False
+        # test reset of zProperties
+        spec.zProperties[zproperty] = default_val
+        org = spec.create_organizer(self.dmd)
+        self.assertEquals(getattr(org, zproperty), new_val,
+            '{} {} zProperty was not set correctly'.format(name, spec.path))
+
+        # test device class removal
+        spec.remove = False
+        removed = spec.remove_organizer(self.dmd)
+        self.assertFalse(removed,
+            ' {} {} should not have been removed'.format(name, spec.path))
+        org = spec.get_organizer(self.dmd)
+        self.assertTrue(org,
+            '{} {} should not have been removed'.format(name, spec.path))
+
+        spec.remove = True
+        # test device class removal
+        removed = spec.remove_organizer(self.dmd)
+        org = spec.get_organizer(self.dmd)
+        if reserved:
+            self.assertFalse(removed,
+                '{} {} should not have been removed'.format(name, spec.path))
+            self.assertTrue(org,
+                '{} {} should not have been removed'.format(name, spec.path))
+        else:
+            self.assertTrue(removed,
+                '{} {} should have been removed'.format(name, spec.path))
+            self.assertIsNone(org,
+                '{} {} should have been removed'.format(name, spec.path))
+
+
+def test_suite():
+    """Return test suite for this module."""
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestOrganizerSpecs))
+    return suite
+
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()


### PR DESCRIPTION
- Fixes ZPS-3190, ZPS-3189, ZPS-810
- Moved common organizer-related functionalty (Device/Event/Process
Class Organizers) to OrganizerSpec

- All now use common methods to acheive consistent behavior
- DeviceClassSpec, EventClassSpec, ProcessClassOrgSpec now consistently
support the "create", "remove", and "reset" attributes
- added zProperty support to EventClassSpec, ProcessClassOrgSpec
- Updated ZenPack class to use new methods
- Added test_organizer_specs.py to verify common functions