### PR TITLE
Support for custom datapoint classes

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDDatasourceSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDDatasourceSpec.py
@@ -10,6 +10,7 @@ from .Spec import Spec
 from .RRDDatapointSpec import RRDDatapointSpec
 from ..base.types import Severity
 
+
 class RRDDatasourceSpec(Spec):
     """RRDDatasourceSpec"""
 
@@ -75,7 +76,8 @@ class RRDDatasourceSpec(Spec):
         self.datapoints = self.specs_from_param(
             RRDDatapointSpec, 'datapoints', datapoints, zplog=self.LOG)
 
-    def create(self, templatespec, template):
+    def create(self, dmd, templatespec, template):
+
         datasource_types = dict(template.getDataSourceOptions())
 
         if not self.sourcetype:
@@ -117,4 +119,4 @@ class RRDDatasourceSpec(Spec):
 
         self.speclog.debug("adding {} datapoints".format(len(self.datapoints)))
         for datapoint_id, datapoint_spec in self.datapoints.items():
-            datapoint_spec.create(self, datasource)
+            datapoint_spec.create(dmd, self, datasource)

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDTemplateSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDTemplateSpec.py
@@ -10,6 +10,7 @@ from .Spec import Spec
 from .RRDThresholdSpec import RRDThresholdSpec
 from .RRDDatasourceSpec import RRDDatasourceSpec
 from .GraphDefinitionSpec import GraphDefinitionSpec
+from Products.ZenModel.RRDDataPoint import RRDDataPoint
 
 
 class RRDTemplateSpec(Spec):
@@ -142,7 +143,7 @@ class RRDTemplateSpec(Spec):
 
         self.speclog.debug("adding {} datasources".format(len(self.datasources)))
         for datasource_id, datasource_spec in self.datasources.items():
-            datasource_spec.create(self, template)
+            datasource_spec.create(dmd, self, template)
 
         self.speclog.debug("adding {} graphs".format(len(self.graphs)))
         for i, (graph_id, graph_spec) in enumerate(self.graphs.items()):
@@ -161,3 +162,10 @@ class RRDTemplateSpec(Spec):
         existing_template = device_class.rrdTemplates._getOb(t_id, None)
         if existing_template:
             device_class.rrdTemplates._delObject(t_id)
+
+    def getDataPointClasses(self, dmd):
+        """Return a list of valid Datapoint classes"""
+        dpClasses = [RRDDataPoint]
+        for zp in dmd.ZenPackManager.packs():
+            dpClasses += zp._getClassesByPath('datapoints')
+        return dpClasses

--- a/ZenPacks/zenoss/ZenPackLib/tests/__init__.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/__init__.py
@@ -18,7 +18,7 @@ from zope.traversing.adapters import DefaultTraversable
 from transaction._transaction import Transaction
 
 # Zenoss Imports
-import Globals 
+import Globals
 import Products.ZenTestCase
 from Products.Five import zcml
 from Products.DataCollector.ApplyDataMap import ApplyDataMap
@@ -172,8 +172,12 @@ class ZPLBaseTestCase(BaseTestCase):
         def getDataSourceClasses():
             return getattr(self, 'datasources', [])
         
+        def _getClassesByPath(type_):
+            return getattr(self, type_, [])
+
         zenpack.getThresholdClasses = getThresholdClasses
         zenpack.getDataSourceClasses = getDataSourceClasses
+        zenpack._getClassesByPath = _getClassesByPath
         return self.dmd.ZenPackManager.packs._getOb(zenpack.id)
 
     def get_config(self, yaml_doc):

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -12,6 +12,7 @@ Release 2.1.0
 
 Features
 
+* Add support for Custom Datapoint classes
 * EventClass, OSProcessOrganizer now support zProperties (ZPS-3189, ZPS-3190)
 * Add "optional" field for thresholds (ZPS-1666)
 * Add support for ZProperty "label" and "description" fields (ZPS-747)

--- a/docs/yaml-monitoring-templates.rst
+++ b/docs/yaml-monitoring-templates.rst
@@ -456,6 +456,12 @@ name
   :Type: string
   :Default Value: *(implied from key in datapoints map)*
 
+type
+  :Description: Type of datapoint. See :ref:`datapoint-types`.
+  :Required: No
+  :Type: string *(must be a valid source type)*
+  :Default Value: None.
+
 description
   :Description: Description of the datapoint's purpose and function.
   :Required: No
@@ -497,6 +503,16 @@ notation follows a pattern of `RRDTYPE_MIN_X_MAX_X` where RRDTYPE is one of "GAU
 and the "MIN_X"/"MAX_X" parameters are optional.  
 
 For example, DERIVE, DERIVE_MIN_0, and DERIVE_MIN_0_MAX_100 are all valid shorthand notation.
+
+.. _datapoint-types:
+
+Datapoint Types
+----------------
+
+By default, datapoint types are determined by the datasource's source code.  To override this behaviour and use a custom datapoint type, 
+the "type" paramter can be set to the class name of any datapoint class available on the system.  This prevents the need to override 
+the "manage_addRRDDataPoint" method within a custom datasource class override.  If the datapoint class comes from a separate ZenPack, be sure to 
+set a dependency in setup.py. Otherwise, the default class (RRDDataPoint) will be used.∂
 
 .. _threshold-fields:
 


### PR DESCRIPTION
- Remove need to override manage_addRRDDataPoint method
- Added "type" attribute to RRDDatapointSpec.  If unspecified, calls
ds.manage_addRRDDataPoint (backwards compat).  If specified, creates the
datapoint directly and adds to ds datapoints.
- Added "_getClassesByPath" ZP method override for unit testing
- Added custom datapoint testing to test_extra_params_types.py