### PR TITLE
Fix omission of "dpName" attribute from dumped graph points (ZPS-855)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/params/GraphPointSpecParams.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/params/GraphPointSpecParams.py
@@ -32,7 +32,7 @@ class GraphPointSpecParams(SpecParams, GraphPointSpec):
         self.extra_params = OrderedDict()
 
         ordered = ('lineType', 'lineWidth', 'stacked', 'format',
-            'legend', 'limit', 'rpn', 'cFunc', 'color')
+            'legend', 'limit', 'rpn', 'cFunc', 'color', 'dpName')
 
         for propname in ordered:
             default_value = getattr(sample_gp, propname, None)

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_template_modify.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_template_modify.py
@@ -275,7 +275,28 @@ device_classes:
                 rpn: 100,/
 """
 
-DIFF = "--- \n+++ \n@@ -4,8 +4,8 @@\n   CPU Utilization:\n     dsnames: [ssCpuRawIdle_ssCpuRawIdle]\n     eventClass: /Perf/CPU\n-    minval: '2'\n-    escalateCount: 5\n+    minval: '3'\n+    escalateCount: 7\n datasources:\n   memBuffer:\n     type: SNMP\n@@ -125,7 +125,6 @@\n     units: load\n     graphpoints:\n       laLoadInt5:\n-        lineType: AREA\n         format: '%0.2lf'\n         rpn: 100,/\n         sequence: 1\n"
+DIFF = """--- 
++++ 
+@@ -4,8 +4,8 @@
+   CPU Utilization:
+     dsnames: [ssCpuRawIdle_ssCpuRawIdle]
+     eventClass: /Perf/CPU
+-    minval: '2'
+-    escalateCount: 5
++    minval: '3'
++    escalateCount: 7
+ datasources:
+   memBuffer:
+     type: SNMP
+@@ -133,7 +133,6 @@
+     graphpoints:
+       laLoadInt5:
+         dpName: laLoadInt5_laLoadInt5
+-        lineType: AREA
+         format: '%0.2lf'
+         rpn: 100,/
+         sequence: 1
+"""
 
 
 class TestTemplateModified(ZPLBaseTestCase):


### PR DESCRIPTION
- Fixes ZPS-855
- Returned "dpName" to list of polled attributes when dumping template
graph points
- Updated test_template_modify.py unit test