### PR TITLE
Perform input validation for ThresholdGraphPoints (ZPS-3714)

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDTemplateSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/RRDTemplateSpec.py
@@ -79,12 +79,15 @@ class RRDTemplateSpec(Spec):
         # check graph point references
         for g_name, g_spec in self.graphs.items():
             for gp_name, gp_spec in g_spec.graphpoints.items():
-                if gp_spec.type_ != 'DataPointGraphPoint':
-                    continue
-                self.check_ds_dp_names(gp_name,
-                                       'Graph Point',
-                                       set([gp_spec.dpName]),
-                                       ds_dp_names)
+                if gp_spec.type_ == 'DataPointGraphPoint':
+                    self.check_ds_dp_names(gp_name, 'Graph Point',
+                        set([gp_spec.dpName]), ds_dp_names)
+                if gp_spec.type_ == 'ThresholdGraphPoint':
+                    th_id = gp_spec.extra_params.get('threshId') or gp_spec.name
+                    th_ids = [th_spec.name for th_spec in self.thresholds.values()]
+                    if th_id not in th_ids:
+                        self.LOG.warn(
+                            'ThresholdGraphPoint {} has no associated threshold'.format(th_id))
 
     def get_ds_dp_names(self):
         """return set of dsname_dpname"""

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_logging_ds_datapoint.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_logging_ds_datapoint.py
@@ -87,6 +87,21 @@ device_classes:
                 dpName: null
 """
 
+BAD_THRESHOLD = """
+name: ZenPacks.zenoss.TestLogging
+
+device_classes:
+  /Server/Zenoss/GraphPoints:
+    templates:
+      GraphPoints:
+        graphs:
+          Health:
+            graphpoints:
+              NotExisting:
+                type: ThresholdGraphPoint
+                threshId: NotExisting
+"""
+
 
 class TestLoggingDatasourceDatapoint(ZPLBaseTestCase):
     disableLogging = False
@@ -108,6 +123,12 @@ class TestLoggingDatasourceDatapoint(ZPLBaseTestCase):
         '[WARNING] Graph Point ssCpuRawIdle has invalid datapoints: null_null\n'
         actual = self.capture.test_yaml(NO_VALID_POINTS)
         self.assertEquals(actual, expected, 'Datapoint validation failed:\n  {}'.format(actual))
+
+    def test_bad_threshold_yaml(self):
+        """Test logging of invalid Threshold Graphpoints (ZPS-3714)"""
+        expected = '[WARNING] ThresholdGraphPoint NotExisting has no associated threshold\n'
+        actual = self.capture.test_yaml(BAD_THRESHOLD)
+        self.assertEquals(actual, expected, 'Threshold graphpoint validation failed:\n  {}'.format(actual))
 
 
 def test_suite():


### PR DESCRIPTION
- Fixes ZPS-3714
- Update RRDTemplateSpec validate_references() to validate threshold ids
- Invalid ThresholdGraphPoint ids create a WARNING log message
- Update test_logging_ds_datapoint to validate this scenario