### PR TITLE
Update __version__ in zenpacklib.py

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/zenpacklib.py
+++ b/ZenPacks/zenoss/ZenPackLib/zenpacklib.py
@@ -27,7 +27,7 @@ This module provides a single integration point for common ZenPacks.
 """
 
 # PEP-396 version. (https://www.python.org/dev/peps/pep-0396/)
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 
 # Must defer definition of TestCase. Otherwise it imports
 # BaseTestCase which puts Zope into testing mode.


### PR DESCRIPTION
- Changed to 2.2.0
- fixes "check_zenpacklib_version" unit test failure