### PR TITLE
Adding width for name column

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassSpec.py
@@ -1222,7 +1222,8 @@ class ClassSpec(Spec):
             "id: 'name',\n"
             "                       dataIndex: 'name',\n"
             "                       header: _t('Name'),\n"
-            "                       renderer: Zenoss.render.zenpacklib_" + self.zenpack.id_prefix + "_entityLinkFromGrid"
+            "                       renderer: Zenoss.render.zenpacklib_" + self.zenpack.id_prefix + "_entityLinkFromGrid,\n"
+            "                       width: 80"
             "}"
         )]
 


### PR DESCRIPTION
[ZPS-4045](https://jira.zenoss.com/browse/ZPS-4045?filter=-1&jql=resolution%20in%20(Unresolved%2C%20Done)%20AND%20assignee%20in%20(currentUser())%20order%20by%20updated%20DESC)

**Issue:** Microsoft HyperV - Name column width needs to be longer for Host HDDs, Virtual Machines, Virtual Switches

