### PR TITLE
Fix handling of `filter_hide_from` class field

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassSpec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/ClassSpec.py
@@ -1114,7 +1114,7 @@ class ClassSpec(Spec):
         faceting = {x.meta_type for x in self.faceting_components}
         hidden = {x.meta_type for x in self.filter_hide_from_class_specs}
 
-        return list(containing | faceting - hidden)
+        return list(containing.union(faceting).difference(hidden))
 
     @property
     def datapoints_to_fetch(self):

--- a/ZenPacks/zenoss/ZenPackLib/tests/test_subcomponent_nav_js.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/test_subcomponent_nav_js.py
@@ -73,6 +73,7 @@ classes:
         label: "Child vApps"
   ComputeResource:
     base: [BaseComponent]
+    filter_hide_from: [Datacenter]
     relationships:
       datacenter:
         order: 1.1
@@ -120,6 +121,7 @@ class TestSubComponentNavJS(ZPLBaseTestCase):
         ''''''
         self.get_test_result('ResourcePool', expected_rp)
         self.get_test_result('VirtualApp', expected_va)
+        self.get_test_result('ComputeResource', '')
 
     def get_test_result(self, name, expected_js):
         cls = self.objects.get(name).get('spec')

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,6 +7,14 @@ Changes
 Version 2.1
 ===========
 
+Release 2.1.2
+-------------
+
+Fixes
+
+* Allow Class.filter_hide_from option to also work for contained components (ZPS-5107)
+
+
 Release 2.1.1
 -------------
 


### PR DESCRIPTION
Fixes ZPS-5107

Add ability for a parent component to hide contained elements from the filter dropdown by using `filter_hide_from` class field.