### PR TITLE
ZenPackLib tests cause Products.Zing tests failing

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/tests/__init__.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/__init__.py
@@ -341,6 +341,8 @@ class ZPLTestCaseLayerBase(ZenossTestCaseLayer):
 
     @classmethod
     def tearDown(cls):
+        if hasattr(cls.tc, '_transaction_abort'):
+            Transaction.abort = cls.tc._transaction_abort
         if cls.device:
             cls.device.deleteDevice()
   


### PR DESCRIPTION
After some tests, that inherited on ZPLTestCaseLayerBase, Transaction.abort method still overridden by empty lambda. Need to turn it back before test finish