### PR TITLE
Prepare code for upgrade PyYAML to 5.x version

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
@@ -256,13 +256,13 @@ class ZenPack(ZenPackBase):
     def object_changed(self, app, object, spec, specparam):
         """Compare new and old objects with prototype creation"""
         # get YAML representation of object
-        object_yaml = yaml.dump(specparam.fromObject(object), Dumper=Dumper)
+        object_yaml = yaml.dump(specparam.fromObject(object), Dumper=Dumper, default_flow_style=None)
 
         # get YAML representation of prototype
         proto_id = '{}-new'.format(spec.name)
         proto_object = spec.create(app.zport.dmd, False, proto_id)
         proto_object_param = specparam.fromObject(proto_object)
-        proto_object_yaml = yaml.dump(proto_object_param, Dumper=Dumper)
+        proto_object_yaml = yaml.dump(proto_object_param, Dumper=Dumper, default_flow_style=None)
         spec.remove(app.zport.dmd, proto_id)
 
         return self.get_yaml_diff(object_yaml, proto_object_yaml)

--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/loaders.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/loaders.py
@@ -17,8 +17,16 @@ from ..functions import ZENOSS_KEYWORDS, JS_WORDS, relname_from_classname, find_
 from .ZenPackLibLog import ZPLOG, DEFAULTLOG
 from ..base.types import Severity, multiline
 
+# Version dependent import
+try:
+    # import for PyYAML >= 5.1
+    from yaml import FullLoader as YamlLoader
+except ImportError:
+    # import for the older version of PyYaml
+    from yaml import Loader as YamlLoader
 
-class OrderedLoader(yaml.Loader):
+
+class OrderedLoader(YamlLoader):
     """Basic ordered mapping YAML loader.
 
     This loader doesn't know about ZenPackSpec. It merely maintains the order
@@ -26,7 +34,7 @@ class OrderedLoader(yaml.Loader):
 
     """
     def __init__(self, *args, **kwargs):
-        yaml.Loader.__init__(self, *args, **kwargs)
+        YamlLoader.__init__(self, *args, **kwargs)
 
         self.add_constructor(
             u'tag:yaml.org,2002:map',

--- a/ZenPacks/zenoss/ZenPackLib/tests/__init__.py
+++ b/ZenPacks/zenoss/ZenPackLib/tests/__init__.py
@@ -186,7 +186,7 @@ class ZPLBaseTestCase(BaseTestCase):
                 'schema': cfg.zenpack_module.schema,
                 'yaml_map': load_yaml_single(
                     yaml_doc, loader=OrderedLoader),
-                'yaml_dump': yaml.dump(cfg, Dumper=Dumper),
+                'yaml_dump': yaml.dump(cfg, Dumper=Dumper, default_flow_style=None),
                 'yaml_from_specparams': yaml.dump(
                     cfg.specparams, Dumper=Dumper),
                 'zenpack_module': cfg.zenpack_module,

--- a/ZenPacks/zenoss/ZenPackLib/tools/load-templates
+++ b/ZenPacks/zenoss/ZenPackLib/tools/load-templates
@@ -73,8 +73,16 @@ from Products.ZenModel.RRDDataSource import RRDDataSource
 from Products.ZenModel.RRDTemplate import RRDTemplate
 from Products.ZenModel.ThresholdClass import ThresholdClass
 
+# Version dependent import
+try:
+    # import for PyYAML >= 5.1
+    from yaml import FullLoader as YamlLoader
+except ImportError:
+    # import for the older version of PyYaml
+    from yaml import Loader as YamlLoader
 
-class OrderedDictYAMLLoader(yaml.Loader):
+
+class OrderedDictYAMLLoader(YamlLoader):
     """
     A YAML loader that loads mappings into ordered dictionaries.
 
@@ -83,7 +91,7 @@ class OrderedDictYAMLLoader(yaml.Loader):
     """
 
     def __init__(self, *args, **kwargs):
-        yaml.Loader.__init__(self, *args, **kwargs)
+        YamlLoader.__init__(self, *args, **kwargs)
 
         self.add_constructor(u'tag:yaml.org,2002:map', type(self).construct_yaml_map)
         self.add_constructor(u'tag:yaml.org,2002:omap', type(self).construct_yaml_map)

--- a/ZenPacks/zenoss/ZenPackLib/tools/yaml_sorter.py
+++ b/ZenPacks/zenoss/ZenPackLib/tools/yaml_sorter.py
@@ -29,13 +29,21 @@ import os
 import re
 from collections import OrderedDict
 
+# Version dependent import
+try:
+    # import for PyYAML >= 5.1
+    from yaml import FullLoader as YamlLoader
+except ImportError:
+    # import for the older version of PyYaml
+    from yaml import Loader as YamlLoader
+
 
 class MyDumper(yaml.Dumper):
     def increase_indent(self, flow=False, indentless=False):
         return super(MyDumper, self).increase_indent(flow, False)
 
 
-def ordered_load(stream, Loader=yaml.Loader, object_pairs_hook=OrderedDict):
+def ordered_load(stream, Loader=YamlLoader, object_pairs_hook=OrderedDict):
     class OrderedLoader(Loader):
         pass
 

--- a/tools/load-templates
+++ b/tools/load-templates
@@ -73,8 +73,16 @@ from Products.ZenModel.RRDDataSource import RRDDataSource
 from Products.ZenModel.RRDTemplate import RRDTemplate
 from Products.ZenModel.ThresholdClass import ThresholdClass
 
+# Version dependent import
+try:
+    # import for PyYAML >= 5.1
+    from yaml import FullLoader as YamlLoader
+except ImportError:
+    # import for the older version of PyYaml
+    from yaml import Loader as YamlLoader
 
-class OrderedDictYAMLLoader(yaml.Loader):
+
+class OrderedDictYAMLLoader(YamlLoader):
     """
     A YAML loader that loads mappings into ordered dictionaries.
 
@@ -83,7 +91,7 @@ class OrderedDictYAMLLoader(yaml.Loader):
     """
 
     def __init__(self, *args, **kwargs):
-        yaml.Loader.__init__(self, *args, **kwargs)
+        YamlLoader.__init__(self, *args, **kwargs)
 
         self.add_constructor(u'tag:yaml.org,2002:map', type(self).construct_yaml_map)
         self.add_constructor(u'tag:yaml.org,2002:omap', type(self).construct_yaml_map)


### PR DESCRIPTION
Fixes ZEN-31325

Fix tests and replace yaml.Loader with yaml.FullLoader (FullLoader is
the safe version of Loader. Avoids arbitrary code execution). This
commit is changing code to be compatible with PyYAML 5.x and saving
backwards compatibility