### PR TITLE
Fix warning during ZenPacks installation

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/base/ZenPack.py
@@ -73,6 +73,15 @@ class ZenPack(ZenPackBase):
             dcspecparam = self._v_specparams.device_classes.get(dcname)
             deviceclass = dcspec.get_organizer(app.zport.dmd)
 
+            # Check if all object properties are filled and fill it if not
+            for pschema in deviceclass._properties:
+                if (
+                    pschema.get('type') is None or
+                    pschema.get('label') is None or
+                    pschema.get('description') is None
+                ):
+                    getattr(deviceclass, pschema['id'])
+
             for mtname, mtspec in dcspec.templates.iteritems():
                 mtspecparam = dcspecparam.templates.get(mtname)
                 self.update_object(app, deviceclass, 'rrdTemplates', mtname, mtspec, mtspecparam)


### PR DESCRIPTION
Fixes ZPS-6974.

This is a back-port of changes in [this commit](https://github.com/zenoss/ZenPacks.zenoss.ZenPackLib/commit/b11758dca2a0de7c1e43561a12e678a86423d8ab) from develop branch to the hotfix/2.1.2.