### PR TITLE
Improve ZPL efficiency during loading yamls

### DIFF
--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/composer.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/composer.py
@@ -1,0 +1,81 @@
+
+from yaml.composer import Composer, ComposerError
+from yaml.nodes import ScalarNode, SequenceNode, MappingNode
+from yaml.error import Mark
+
+class ComposerFromDict(Composer):
+    # composer for non-streaming loader that takes a dictionary
+    # as the source of the nodes
+
+    def __init__(self, dataDict, tag=u'tag:yaml.org,2002:map'):
+        self.dataDict = dataDict
+        self.tag = tag
+        # need some kind of mark to keep some logging stuff from failing
+        self.dummyMark = Mark("combinedYaml", 0, 0, 0, None, 0)
+
+    def dispose(self):
+        # since there is no parser, we need to fake out the dispose method
+        # migth as well dispose of the dict we had passed in
+        del self.dataDict
+
+    def check_node(self):
+        # called to check if there's a node to load
+        # since this composer only supports one node but laod_all
+        # uses this as a while-condition, we will return true
+        # only if we haven't composed the node yet
+
+        return self.dataDict is not None
+     
+    def get_single_node(self):
+        if not self.dataDict:
+            raise ComposerError(None, None, "source dict missing or empty", None)
+        # Compose the root node and everything below it
+        node = self.compose_node(self.dataDict)
+        node.tag = self.tag
+        return node
+
+    get_node = get_single_node  # we will only ever have one node
+
+    def compose_node(self, obj):
+        if isinstance(obj, (int, str, float, bool, type(None))): 
+            node = self.compose_scalar_node(obj)
+        elif isinstance(obj, (list, tuple, set)):
+            node = self.compose_sequence_node(obj)
+        elif isinstance(obj, (dict,)):
+            node = self.compose_mapping_node(obj)
+        else:
+            node = self.compose_scalar_node(obj)
+        return node
+
+    def compose_scalar_node(self, obj):
+        if isinstance(obj, (bool,)):
+            tag = u'tag:yaml.org,2002:bool'
+        elif isinstance(obj, (str, unicide)):
+            tag = u'tag:yaml.org,2002:str'
+        elif isinstance(obj, (float,)):
+            tag = u'tag:yaml.org,2002:float'
+        elif isinstance(obj, (int,)):
+            tag = u'tag:yaml.org,2002:int'
+        elif isinstance(obj, (type(None),)):
+            tag = u'tag:yaml.org,2002:null'
+        else:
+            tag = u'tag:yaml.org,2002:str'
+        node = ScalarNode(tag, obj, start_mark=self.dummyMark, end_mark=self.dummyMark)
+        return node
+
+    def compose_sequence_node(self, obj):
+        tag = u'tag:yaml.org,2002:seq'
+        node = SequenceNode(tag, [], start_mark=self.dummyMark, end_mark=self.dummyMark)
+        for value in obj:
+            node.value.append(self.compose_node(value))
+        return node
+
+    def compose_mapping_node(self, obj):
+        tag = u'tag:yaml.org,2002:map'
+        node = MappingNode(tag, [], start_mark=self.dummyMark, end_mark=self.dummyMark)
+        for key, value in obj.items():
+            item_key = self.compose_node(key)
+            item_value = self.compose_node(value)
+            node.value.append((item_key, item_value))
+        return node
+

--- a/ZenPacks/zenoss/ZenPackLib/lib/helpers/composer.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/helpers/composer.py
@@ -50,7 +50,7 @@ class ComposerFromDict(Composer):
     def compose_scalar_node(self, obj):
         if isinstance(obj, (bool,)):
             tag = u'tag:yaml.org,2002:bool'
-        elif isinstance(obj, (str, unicide)):
+        elif isinstance(obj, (str, unicode)):
             tag = u'tag:yaml.org,2002:str'
         elif isinstance(obj, (float,)):
             tag = u'tag:yaml.org,2002:float'

--- a/ZenPacks/zenoss/ZenPackLib/lib/spec/Spec.py
+++ b/ZenPacks/zenoss/ZenPackLib/lib/spec/Spec.py
@@ -140,6 +140,11 @@ def RelationshipLengthProperty(relationship_name):
     return property(getter)
 
 
+class LogAdapter(logging.LoggerAdapter):
+    def process(self, msg, kwargs):
+        return '{} {}'.format(self.extra['context'], msg), kwargs
+
+
 class Spec(object):
     """Abstract base class for specifications."""
 
@@ -152,10 +157,6 @@ class Spec(object):
     def __init__(self, _source_location=None, zplog=None):
         if zplog:
             self.LOG = zplog
-
-        class LogAdapter(logging.LoggerAdapter):
-            def process(self, msg, kwargs):
-                return '{} {}'.format(self.extra['context'], msg), kwargs
 
         self.source_location = _source_location
         self.speclog = LogAdapter(self.LOG, {'context': self})

--- a/ZenPacks/zenoss/ZenPackLib/migrate/FixReplacementTemplates.py
+++ b/ZenPacks/zenoss/ZenPackLib/migrate/FixReplacementTemplates.py
@@ -31,7 +31,7 @@ class FixReplacementTemplates(ZenPackMigration):
                 templs = obj.zDeviceTemplates
                 for templ in list(templs):
                     if templ.endswith('-replacement') or templ.endswith('-addition'):
-                        if availtempls = None:
+                        if availtempls is None:
                             availtempls = [t.id for t in obj.getAvailableTemplates()]
                         base = templ.rsplit('-',1)[0]
                         if base in availtempls:

--- a/ZenPacks/zenoss/ZenPackLib/migrate/FixReplacementTemplates.py
+++ b/ZenPacks/zenoss/ZenPackLib/migrate/FixReplacementTemplates.py
@@ -49,8 +49,6 @@ class FixReplacementTemplates(ZenPackMigration):
 
     def migrate(self, pack):
         LOG.info("fix zDeviceTemplates on /Devices and subclasses")
-
-        )
         deviceClass = pack.dmd.Devices
 
         # Migrate zDeviceTemplates on Device Classes

--- a/ZenPacks/zenoss/ZenPackLib/zenpacklib.py
+++ b/ZenPacks/zenoss/ZenPackLib/zenpacklib.py
@@ -27,7 +27,7 @@ This module provides a single integration point for common ZenPacks.
 """
 
 # PEP-396 version. (https://www.python.org/dev/peps/pep-0396/)
-__version__ = "2.2.0"
+__version__ = "2.1.3"
 
 # Must defer definition of TestCase. Otherwise it imports
 # BaseTestCase which puts Zope into testing mode.

--- a/docs/yaml-monitoring-templates.rst
+++ b/docs/yaml-monitoring-templates.rst
@@ -214,7 +214,7 @@ graphs
 
 .. note::
 
-  ZenPackLib also allows for defining a replacement or additional template by adding "-replacement" or "-addition" to the end of the template name.  For example, a defined *Device-replacement* template will replace the existing Device template on a device class.  A defined *Device-addition* template will be applied in addition to the existing Device template on a device class.
+  ZenPackLib also allows for defining a replacement or additional template by adding "-replacement" or "-addition" to the end of the template name.  For example, a defined *Device-replacement* template will replace the existing Device template on a device class.  A defined *Device-addition* template will be applied in addition to the existing Device (or Device-replacement) template on a device class.
 
 
 .. _datasource-fields:


### PR DESCRIPTION
Stop ZPL load_yaml from reading and parsing all the yaml files only to re-export them as yaml text and re-load it all again.
Stop wasting time and memory making a new LogAdapter class for each Spec instance.